### PR TITLE
As described in issue 487, FT expects cutoff_time dataframe's columns…

### DIFF
--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -176,7 +176,11 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
             raise TypeError("cutoff_time times must be datetime type: try casting via pd.to_datetime(cutoff_time['time'])")
     assert (cutoff_time[['instance_id', 'time']].duplicated().sum() == 0), \
         "Duplicated rows in cutoff time dataframe."
-    pass_columns = [column_name for column_name in cutoff_time.columns[2:]]
+    # move instance_id and time columns to first and second position in the cutoff_time dataframe
+    column_names = cutoff_time.columns.tolist()
+    column_names.insert(0, column_names.pop(column_names.index('instance_id')))
+    column_names.insert(1, column_names.pop(column_names.index('time')))
+    pass_columns = [column_name for column_name in column_names[2:]]
 
     if _check_time_type(cutoff_time['time'].iloc[0]) is None:
         raise ValueError("cutoff_time time values must be datetime or numeric")

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -264,6 +264,21 @@ def test_cutoff_time_binning():
         assert binned_cutoff_times['time'][i] == labels[i]
 
 
+def test_cutoff_time_columns_order(es):
+    property_feature = ft.Feature(es['log']['id'], parent_entity=es['customers'], primitive=Count)
+    times = [datetime(2011, 4, 10), datetime(2011, 4, 11), datetime(2011, 4, 7)]
+    cutoff_time = pd.DataFrame({'dummy_col_1':[1,2,3],
+                                'instance_id': [0, 1, 2],
+                                'dummy_col_2':[True, False, False],
+                                'time': times})
+    feature_matrix = calculate_feature_matrix([property_feature],
+                                              es,
+                                              cutoff_time=cutoff_time)
+
+    labels = [0, 10, 5]
+    assert (feature_matrix[property_feature.get_name()] == labels).values.all()
+
+
 def test_training_window(es):
     property_feature = ft.Feature(es['log']['id'], parent_entity=es['customers'], primitive=Count)
     top_level_agg = ft.Feature(es['customers']['id'], parent_entity=es[u'régions'], primitive=Count)


### PR DESCRIPTION
- As described in issue 487, FT expects cutoff_time dataframe's columns to be in instance_id_time, ... order. This commit addresses this issue by first moving the expected columns to the first and second position before cracking on with the rest of the code 

- A unittest has been added to check the functionality of the added code