### PR TITLE
Adding logic for the default value when the parent is missing

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,7 @@ Changelog
     * Enhancements
         * Added drop_first as param in encode_features (:pr:`647`)
         * Generate transform features of direct features (:pr:`623`)
+        * When calculating direct features use default value if parent missing (:pr:`688`)
     * Fixes
         * Fix performance regression in DFS (:pr:`637`)
         * Fix deserialization of feature relationship path (:pr:`665`)
@@ -28,7 +29,7 @@ Changelog
 
     Thanks to the following people for contributing to this release:
     :user:`ayushpatidar`, :user:`CJStadler`, :user:`gsheni`,
-    :user:`jeff-hernandez`, :user:`kmax12`, :user:`rwedge`, :user:`zhxt95`
+    :user:`jeff-hernandez`, :user:`kmax12`, :user:`rwedge`, :user:`zhxt95`, :user:`iaroslav0`
 
 **v0.9.1 July 3, 2019**
     * Enhancements

--- a/featuretools/computational_backends/feature_set_calculator.py
+++ b/featuretools/computational_backends/feature_set_calculator.py
@@ -483,7 +483,15 @@ class FeatureSetCalculator(object):
 
         new_df = child_df.merge(merge_df, left_on=merge_var, right_index=True,
                                 how='left')
+        # Handle default values
+        fillna_dict = {}
+        for f in features:
+            feature_defaults = {name: f.default_value
+                                for name in f.get_feature_names()}
+            fillna_dict.update(feature_defaults)
 
+        new_df.fillna(fillna_dict, inplace=True)
+ 
         return new_df
 
     def _calculate_agg_features(self, features, frame, df_trie):

--- a/featuretools/computational_backends/feature_set_calculator.py
+++ b/featuretools/computational_backends/feature_set_calculator.py
@@ -491,7 +491,7 @@ class FeatureSetCalculator(object):
             fillna_dict.update(feature_defaults)
 
         new_df.fillna(fillna_dict, inplace=True)
- 
+
         return new_df
 
     def _calculate_agg_features(self, features, frame, df_trie):

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -1249,18 +1249,18 @@ def test_missing_parent():
         "session_id": ["a", "a", "b", "c"],
         "value": [1, 1, 1, 1]
     })
-    
+
     sessions = pd.DataFrame({
         "id": ["a", "b"]
     })
 
     es = ft.EntitySet()
     es.entity_from_dataframe(entity_id="transactions",
-                            dataframe=transactions,
-                            index="id")
+                             dataframe=transactions,
+                             index="id")
     es.entity_from_dataframe(entity_id="sessions",
-                            dataframe=sessions,
-                            index="id")
+                             dataframe=sessions,
+                             index="id")
 
     es.add_relationship(ft.Relationship(es["sessions"]["id"], es["transactions"]["session_id"]))
 


### PR DESCRIPTION
### Pull Request Description

Adding logic for the default value in _calculate_direct_features. Now, if the parent missing, the calculated value will be the default value (not a 'nan').

Fixes #682 