### PR TITLE
Fix ft.show_info() doesn't work in Jupyter(#650)

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,7 @@ Changelog
         * Don't calculate dependencies of unnecessary features (:pr:`667`)
         * Prevent normalize entity's new entity having same index as base entity (:pr:`681`)
         * Update variable type inference to better check for string values (:pr:`683`)
+        * Fix ft.show_info() doesn't work in Jupyter (:pr:`690`)
     * Changes
         * Moved dask, distributed imports (:pr:`634`)
     * Documentation Changes
@@ -28,7 +29,7 @@ Changelog
 
     Thanks to the following people for contributing to this release:
     :user:`ayushpatidar`, :user:`CJStadler`, :user:`gsheni`,
-    :user:`jeff-hernandez`, :user:`kmax12`, :user:`rwedge`, :user:`zhxt95`
+    :user:`jeff-hernandez`, :user:`kmax12`, :user:`rwedge`, :user:`zhxt95`, :user:`FreshLeaf8865`
 
 **v0.9.1 July 3, 2019**
     * Enhancements

--- a/featuretools/utils/cli_utils.py
+++ b/featuretools/utils/cli_utils.py
@@ -15,7 +15,8 @@ deps = ["numpy", "pandas", "tqdm", "toolz", "PyYAML", "cloudpickle",
 
 
 def show_info():
-    subprocess.run(["featuretools", "info"])
+    res = subprocess.run(["featuretools", "info"], stdout=subprocess.PIPE)
+    print(res.stdout.decode('utf-8'))
 
 
 def print_info():


### PR DESCRIPTION
### Pull Request Description
Fix the issue that ft.show_info() doesn't work in Jupyter.

-----
*After creating the pull request: in order to pass the **changelog_updated** check you will need to update the "Future Release" section of* `docs/source/changelog.rst` *to include this pull request.*
