### PR TITLE
Fix for haversine error (#453) Handle NaNs in haversine transform_primitive 

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,7 @@ Changelog
         * Select columns of dataframe using a list (:pr:`615`)
         * Change type of features calculated on Index features to Categorical (:pr:`602`)
         * Specify Dask version in requirements for python 2 (:pr:`627`)
+        * Allow haversine function to accepts NaNs (:pr:`693`)
     * Changes
         * Remove unused variance_selection.py file (:pr:`613`)
         * Remove Timedelta data param (:pr:`619`)

--- a/featuretools/primitives/standard/transform_primitive.py
+++ b/featuretools/primitives/standard/transform_primitive.py
@@ -593,6 +593,19 @@ class Haversine(TransformPrimitive):
 
     def get_function(self):
         def haversine(latlong1, latlong2):
+            #Convert nan's to (nan,nan) tuple to allow them to flow through the calcs
+            if latlong1.hasnans:
+                #If all values are nan, latlong1 could have another datatype than tuples
+                if latlong1.dtype != 'object':
+                    latlong1 = latlong1.astype('object')
+                nan_tuple_series = pd.Series([(np.nan,np.nan) for x in range(len(latlong1))])
+                latlong1 = np.where(latlong1.isna(),nan_tuple_series,latlong1)
+            if latlong2.hasnans:
+                #If all values are nan, latlong2 could have another datatype than tuples
+                if latlong2.dtype != 'object':
+                    latlong2 = latlong2.astype('object')
+                nan_tuple_series = pd.Series([(np.nan,np.nan) for x in range(len(latlong2))])
+                latlong2 = np.where(latlong2.isna(),nan_tuple_series,latlong2)
             lat_1s = np.array([x[0] for x in latlong1])
             lon_1s = np.array([x[1] for x in latlong1])
             lat_2s = np.array([x[0] for x in latlong2])


### PR DESCRIPTION
Prior to handling NaN's, the code first checks if any are present (to save calculation time). Time with old method that failed on NaNs was 650 ms per 1 million rows. Time for data with no NaNs is now 750ms per 1 million rows. When NaNs are present, time is 1.5 seconds per 1 million rows, even using np.where to fix NaNs in a vectorized way.

### Pull Request Description
This allows the Haversine function to handle NaN values as inputs. It does so in a vectorized way so that performance is affected as little as possible.

-----
*After creating the pull request: in order to pass the **changelog_updated** check you will need to update the "Future Release" section of* `docs/source/changelog.rst` *to include this pull request.*
