### PR TITLE
Add First primitive

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 ---------
 **Future Release**
     * Enhancements
+        * Added First primitive (:pr:`770`)
     * Fixes
     * Updates
     * Changes

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,7 +14,7 @@ Changelog
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
-    :user:`kmax12`, :user:`rwedge`
+    :user:`kmax12`, :user:`rwedge`, :user:`jeffzi`
 
 **v0.11.0 Sep 30, 2019**
 

--- a/featuretools/primitives/standard/aggregation_primitives.py
+++ b/featuretools/primitives/standard/aggregation_primitives.py
@@ -371,6 +371,7 @@ class Std(AggregationPrimitive):
     def get_function(self):
         return np.std
 
+
 class First(AggregationPrimitive):
     """Determines the first value in a list.
 
@@ -388,6 +389,7 @@ class First(AggregationPrimitive):
         def pd_first(x):
             return x.iloc[0]
         return pd_first
+
 
 class Last(AggregationPrimitive):
     """Determines the last value in a list.

--- a/featuretools/primitives/standard/aggregation_primitives.py
+++ b/featuretools/primitives/standard/aggregation_primitives.py
@@ -371,6 +371,23 @@ class Std(AggregationPrimitive):
     def get_function(self):
         return np.std
 
+class First(AggregationPrimitive):
+    """Determines the first value in a list.
+
+    Examples:
+        >>> first = First()
+        >>> first([1, 2, 3, 4, 5, None])
+        1.0
+    """
+    name = "first"
+    input_types = [Variable]
+    return_type = None
+    stack_on_self = False
+
+    def get_function(self):
+        def pd_first(x):
+            return x.iloc[0]
+        return pd_first
 
 class Last(AggregationPrimitive):
     """Determines the last value in a list.


### PR DESCRIPTION
### Add First aggregation primitive

The `First` primitive can be very useful, for example, to create features based on the first transaction done by a customer.