### PR TITLE
Add unit parameter to AvgTimeBetween

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,12 +8,14 @@ Changelog
     * Updates
     * Changes
         * Drop Python 2 support (:pr:`759`)
+        * Add unit parameter to AvgTimeBetween (:pr:`771`)
+
     * Documentation Changes
         * Update featuretools slack link (:pr:`765`)
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
-    :user:`kmax12`, :user:`rwedge`
+    :user:`kmax12`, :user:`rwedge`, :user:`jeffzi`
 
 **v0.11.0 Sep 30, 2019**
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,7 +9,6 @@ Changelog
     * Changes
         * Drop Python 2 support (:pr:`759`)
         * Add unit parameter to AvgTimeBetween (:pr:`771`)
-
     * Documentation Changes
         * Update featuretools slack link (:pr:`765`)
     * Testing Changes

--- a/featuretools/primitives/standard/aggregation_primitives.py
+++ b/featuretools/primitives/standard/aggregation_primitives.py
@@ -282,9 +282,6 @@ class AvgTimeBetween(AggregationPrimitive):
         >>> avg_time_between(times)
         375.0
         >>> avg_time_between = AvgTimeBetween(unit="minutes")
-        >>> times = [datetime(2010, 1, 1, 11, 45, 0),
-        ...          datetime(2010, 1, 1, 11, 55, 15),
-        ...          datetime(2010, 1, 1, 11, 57, 30)]
         >>> avg_time_between(times)
         6.25
     """

--- a/featuretools/primitives/standard/aggregation_primitives.py
+++ b/featuretools/primitives/standard/aggregation_primitives.py
@@ -268,6 +268,11 @@ class AvgTimeBetween(AggregationPrimitive):
         elapsed between consecutive events. If there are fewer
         than 2 non-null values, return `NaN`.
 
+    Args:
+        unit (str): Defines the unit of time.
+            Defaults to seconds. Acceptable values:
+            years, months, days, hours, minutes, seconds, milliseconds, nanoseconds
+
     Examples:
         >>> from datetime import datetime
         >>> avg_time_between = AvgTimeBetween()

--- a/featuretools/primitives/standard/aggregation_primitives.py
+++ b/featuretools/primitives/standard/aggregation_primitives.py
@@ -264,7 +264,7 @@ class AvgTimeBetween(AggregationPrimitive):
     """Computes the average number of seconds between consecutive events.
 
     Description:
-        Given a list of datetimes, return the average number of seconds
+        Given a list of datetimes, return the average time (default in seconds)
         elapsed between consecutive events. If there are fewer
         than 2 non-null values, return `NaN`.
 
@@ -276,10 +276,19 @@ class AvgTimeBetween(AggregationPrimitive):
         ...          datetime(2010, 1, 1, 11, 57, 30)]
         >>> avg_time_between(times)
         375.0
+        >>> avg_time_between = AvgTimeBetween(unit="minutes")
+        >>> times = [datetime(2010, 1, 1, 11, 45, 0),
+        ...          datetime(2010, 1, 1, 11, 55, 15),
+        ...          datetime(2010, 1, 1, 11, 57, 30)]
+        >>> avg_time_between(times)
+        6.25
     """
     name = "avg_time_between"
     input_types = [DatetimeTimeIndex]
     return_type = Numeric
+
+    def __init__(self, unit="seconds"):
+        self.unit = unit.lower()
 
     def get_function(self):
         def pd_avg_time_between(x):
@@ -307,7 +316,7 @@ class AvgTimeBetween(AggregationPrimitive):
             # diff_in_ns = x.diff().iloc[1:].astype('int64')
             # diff_in_seconds = diff_in_ns * 1e-9
             # avg = diff_in_seconds.mean()
-            return avg
+            return convert_time_units(avg, self.unit)
         return pd_avg_time_between
 
 


### PR DESCRIPTION
### Added unit parameter to AvgTimeBetween

This PR adds a `unit` parameter to `AvgTimeBetween` primitive, similary to `TimeSinceFirst`, `TimeSinceLast` and `TimeSincePrevious`.