### PR TITLE
Disable PIP progress bars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
       - run : |
           virtualenv venv
           source venv/bin/activate
-          pip config set global.progress_bar off
+          pip config --site set global.progress_bar off
           pip install -e unpacked_sdist/
           pip install -r unpacked_sdist/test-requirements.txt
       - persist_to_workspace:
@@ -147,7 +147,7 @@ jobs:
       - run: |
           virtualenv venv
           source venv/bin/activate
-          pip config set global.progress_bar off
+          pip config --site set global.progress_bar off
           pip install -e unpacked_sdist/[complete]
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
       - run : |
           virtualenv venv
           source venv/bin/activate
-          pip config --user set global.progress_bar off
+          pip config set global.progress_bar off
           pip install -e unpacked_sdist/
           pip install -r unpacked_sdist/test-requirements.txt
       - persist_to_workspace:
@@ -81,7 +81,6 @@ jobs:
           steps:
             - run: |
                 source venv/bin/activate
-                pip config --user set global.progress_bar off
                 pip install "$(cat dev-requirements.txt | grep codecov)"
                 coverage erase
                 cd unpacked_sdist/
@@ -113,7 +112,6 @@ jobs:
           at: ~/featuretools
       - run: |
           source venv/bin/activate
-          pip config --user set global.progress_bar off
           pip install -r unpacked_sdist/dev-requirements.txt
       - run: source venv/bin/activate && make lint
 
@@ -129,7 +127,6 @@ jobs:
           at: ~/featuretools
       - run: |
           source venv/bin/activate
-          pip config --user set global.progress_bar off
           pip install -r unpacked_sdist/dev-requirements.txt
       - run: |
           source venv/bin/activate
@@ -150,7 +147,7 @@ jobs:
       - run: |
           virtualenv venv
           source venv/bin/activate
-          pip config --user set global.progress_bar off
+          pip config set global.progress_bar off
           pip install -e unpacked_sdist/[complete]
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ jobs:
       - run : |
           virtualenv venv
           source venv/bin/activate
+          pip config --user set global.progress_bar off
           pip install -e unpacked_sdist/
           pip install -r unpacked_sdist/test-requirements.txt
       - persist_to_workspace:
@@ -80,6 +81,7 @@ jobs:
           steps:
             - run: |
                 source venv/bin/activate
+                pip config --user set global.progress_bar off
                 pip install "$(cat dev-requirements.txt | grep codecov)"
                 coverage erase
                 cd unpacked_sdist/
@@ -111,6 +113,7 @@ jobs:
           at: ~/featuretools
       - run: |
           source venv/bin/activate
+          pip config --user set global.progress_bar off
           pip install -r unpacked_sdist/dev-requirements.txt
       - run: source venv/bin/activate && make lint
 
@@ -126,6 +129,7 @@ jobs:
           at: ~/featuretools
       - run: |
           source venv/bin/activate
+          pip config --user set global.progress_bar off
           pip install -r unpacked_sdist/dev-requirements.txt
       - run: |
           source venv/bin/activate
@@ -146,6 +150,7 @@ jobs:
       - run: |
           virtualenv venv
           source venv/bin/activate
+          pip config --user set global.progress_bar off
           pip install -e unpacked_sdist/[complete]
       - run:
           command: |

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,7 +18,7 @@ Changelog
         * Disable PIP progress bars (:pr:`775`)
 
     Thanks to the following people for contributing to this release:
-    :user:`kmax12`, :user:`rwedge`, :user:`ablacke-ayx`, :user:`jeffzi`
+    :user:`kmax12`, :user:`rwedge`, :user:`ablacke-ayx`, :user:`jeffzi`, :user:`BoopBoopBeepBoop`
 
 **v0.11.0 Sep 30, 2019**
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -15,6 +15,7 @@ Changelog
         * Update featuretools slack link (:pr:`765`)
     * Testing Changes
         * CircleCI fixes (:pr:`774`)
+        * Disable PIP progress bars (:pr:`775`)
 
     Thanks to the following people for contributing to this release:
     :user:`kmax12`, :user:`rwedge`, :user:`ablacke-ayx`, :user:`jeffzi`


### PR DESCRIPTION
### Pull Request Description

Disables the pip progress bars in circleCI to declutter the build logs 

-----
*After creating the pull request: in order to pass the **changelog_updated** check you will need to update the "Future Release" section of* `docs/source/changelog.rst` *to include this pull request.*
