### PR TITLE
Add readthedocs support

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,21 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - method: pip
+      path: .
+    - requirements: dev-requirements.txt

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -13,6 +13,7 @@ Changelog
         * Add unit parameter to AvgTimeBetween (:pr:`771`)
     * Documentation Changes
         * Update featuretools slack link (:pr:`765`)
+        * Set up repo to use Read the Docs (:pr:`776`)
     * Testing Changes
         * CircleCI fixes (:pr:`774`)
 


### PR DESCRIPTION
### Pull Request Description

Adds a config file to allow readthedocs to build our documentation

-----
*After creating the pull request: in order to pass the **changelog_updated** check you will need to update the "Future Release" section of* `docs/source/changelog.rst` *to include this pull request.*
