### PR TITLE
Custom naming for multi output primitives

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,13 +5,13 @@ Changelog
 **Future Release**
     * Enhancements
         * Added First primitive (:pr:`770`)
+        * Allow custom naming for multi-output primitives (:pr:`780`)
     * Fixes
         * Prevents user from removing base entity time index using additional_variables (:pr:`768`)
     * Updates
     * Changes
         * Drop Python 2 support (:pr:`759`)
         * Add unit parameter to AvgTimeBetween (:pr:`771`)
-        * Allow custom naming for multi-output primitives (:pr:`780`)
     * Documentation Changes
         * Update featuretools slack link (:pr:`765`)
         * Set up repo to use Read the Docs (:pr:`776`)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,13 +10,14 @@ Changelog
     * Changes
         * Drop Python 2 support (:pr:`759`)
         * Add unit parameter to AvgTimeBetween (:pr:`771`)
+        * Allow custom naming for multi-output primitives (:pr:`780`)
     * Documentation Changes
         * Update featuretools slack link (:pr:`765`)
     * Testing Changes
         * CircleCI fixes (:pr:`774`)
 
     Thanks to the following people for contributing to this release:
-    :user:`kmax12`, :user:`rwedge`, :user:`jeffzi`
+    :user:`kmax12`, :user:`rwedge`, :user:`jeffzi`, :user:'thehomebrewnerd'
 
 **v0.11.0 Sep 30, 2019**
 

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -83,9 +83,8 @@ class FeatureBase(object):
         return self._name
 
     def get_names(self):
-        n = self.number_output_features
         if not self._names:
-            self._names = [self.generate_name() + "[{}]".format(i) for i in range(n)]
+            self._names = self.generate_names()
         return self._names
 
     def get_feature_names(self):
@@ -618,6 +617,13 @@ class AggregationFeature(FeatureBase):
                                             where_str=self._where_str(),
                                             use_prev_str=self._use_prev_str())
 
+    def generate_names(self):
+        return self.primitive.generate_names(base_feature_names=[bf.get_name() for bf in self.base_features],
+                                             relationship_path_name=self.relationship_path_name(),
+                                             parent_entity_id=self.parent_entity.id,
+                                             where_str=self._where_str(),
+                                             use_prev_str=self._use_prev_str())
+
     def get_arguments(self):
         return {
             'name': self._name,
@@ -667,6 +673,9 @@ class TransformFeature(FeatureBase):
 
     def generate_name(self):
         return self.primitive.generate_name(base_feature_names=[bf.get_name() for bf in self.base_features])
+
+    def generate_names(self):
+        return self.primitive.generate_names(base_feature_names=[bf.get_name() for bf in self.base_features])
 
     def get_arguments(self):
         return {

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -722,6 +722,12 @@ class GroupByTransformFeature(TransformFeature):
         _name = self.primitive.generate_name(base_names)
         return u"{} by {}".format(_name, self.groupby.get_name())
 
+    def generate_names(self):
+        base_names = [bf.get_name() for bf in self.base_features[:-1]]
+        _names = self.primitive.generate_names(base_names)
+        names = [name + " by {}".format(self.groupby.get_name()) for name in _names]
+        return names
+
     def get_arguments(self):
         # Do not include groupby in base_features.
         feature_names = [feat.unique_name() for feat in self.base_features

--- a/featuretools/primitives/base/aggregation_primitive_base.py
+++ b/featuretools/primitives/base/aggregation_primitive_base.py
@@ -28,11 +28,12 @@ class AggregationPrimitive(PrimitiveBase):
     def generate_names(self, base_feature_names, relationship_path_name,
                        parent_entity_id, where_str, use_prev_str):
         n = self.number_output_features
-        return [self.generate_name(base_feature_names,
-                                   relationship_path_name,
-                                   parent_entity_id,
-                                   where_str,
-                                   use_prev_str) + "[%s]" % i for i in range(n)]
+        base_name = self.generate_name(base_feature_names,
+                                       relationship_path_name,
+                                       parent_entity_id,
+                                       where_str,
+                                       use_prev_str)
+        return [base_name + "[%s]" % i for i in range(n)]
 
 
 def make_agg_primitive(function, input_types, return_type, name=None,

--- a/featuretools/primitives/base/aggregation_primitive_base.py
+++ b/featuretools/primitives/base/aggregation_primitive_base.py
@@ -25,6 +25,15 @@ class AggregationPrimitive(PrimitiveBase):
             self.get_args_string(),
         )
 
+    def generate_names(self, base_feature_names, relationship_path_name,
+                       parent_entity_id, where_str, use_prev_str):
+        n = self.number_output_features
+        return [self.generate_name(base_feature_names,
+                                   relationship_path_name,
+                                   parent_entity_id,
+                                   where_str,
+                                   use_prev_str) + "[%s]" % i for i in range(n)]
+
 
 def make_agg_primitive(function, input_types, return_type, name=None,
                        stack_on_self=True, stack_on=None,

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -46,6 +46,9 @@ class PrimitiveBase(object):
     def generate_name(self):
         raise NotImplementedError("Subclass must implement")
 
+    def generate_names(self):
+        raise NotImplementedError("Subclass must implement")
+
     def get_function(self):
         raise NotImplementedError("Subclass must implement")
 

--- a/featuretools/primitives/base/transform_primitive_base.py
+++ b/featuretools/primitives/base/transform_primitive_base.py
@@ -20,6 +20,10 @@ class TransformPrimitive(PrimitiveBase):
             self.get_args_string(),
         )
 
+    def generate_names(self, base_feature_names):
+        n = self.number_output_features
+        return [self.generate_name(base_feature_names) + "[%s]" % i for i in range(n)]
+
 
 def make_trans_primitive(function, input_types, return_type, name=None,
                          description=None, cls_attributes=None,

--- a/featuretools/primitives/base/transform_primitive_base.py
+++ b/featuretools/primitives/base/transform_primitive_base.py
@@ -22,7 +22,8 @@ class TransformPrimitive(PrimitiveBase):
 
     def generate_names(self, base_feature_names):
         n = self.number_output_features
-        return [self.generate_name(base_feature_names) + "[%s]" % i for i in range(n)]
+        base_name = self.generate_name(base_feature_names)
+        return [base_name + "[%s]" % i for i in range(n)]
 
 
 def make_trans_primitive(function, input_types, return_type, name=None,


### PR DESCRIPTION
### Pull Request Description
Updates to allow for custom naming of multioutput primitives. Implements a `generate_names` method in `PrimitiveBase` class that can be overridden when creating a custom primitive.

This change was discussed in Issues #591 and #593. 