### PR TITLE
Fix issue when multioutput primitives supplied to dfs as groupby primitive

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,7 @@ Changelog
         * Added First primitive (:pr:`770`)
     * Fixes
         * Prevents user from removing base entity time index using additional_variables (:pr:`768`)
+        * Fixes error when a multioutput primitive was supplied to dfs as a groupby trans primitive (:pr:`786`)
     * Updates
     * Changes
         * Drop Python 2 support (:pr:`759`)

--- a/featuretools/computational_backends/feature_set_calculator.py
+++ b/featuretools/computational_backends/feature_set_calculator.py
@@ -447,8 +447,8 @@ class FeatureSetCalculator(object):
         groups = frame[groupby].unique()  # get all the unique group name to iterate over later
 
         for f in features:
-            feature_vals = []
             for group in groups:
+                feature_vals = []
                 # skip null key if it exists
                 if pd.isnull(group):
                     continue
@@ -476,13 +476,15 @@ class FeatureSetCalculator(object):
                         value = pd.Series(value, index=variable_data[0].index)
                     feature_vals.append(value)
 
-            # Note
-            # more efficient in pandas to concat and update only once
-            if feature_vals:
-                if f.number_output_features > 1:
-                    frame[f.get_names()].update(pd.concat(feature_vals))
-                else:
-                    frame[f.get_name()].update(pd.concat(feature_vals))
+                # Note
+                # more efficient in pandas to concat and update only once
+                if feature_vals:
+                    if f.number_output_features > 1:
+                        update_df = pd.concat(feature_vals, axis=1)
+                        update_df.columns = f.get_names()
+                        frame.update(update_df)
+                    else:
+                        frame[f.get_name()].update(pd.concat(feature_vals))
 
             progress_callback(1 / float(self.num_features))
 

--- a/featuretools/computational_backends/feature_set_calculator.py
+++ b/featuretools/computational_backends/feature_set_calculator.py
@@ -447,8 +447,9 @@ class FeatureSetCalculator(object):
         groups = frame[groupby].unique()  # get all the unique group name to iterate over later
 
         for f in features:
+            feature_vals = []
             for group in groups:
-                feature_vals = []
+                group_vals = []
                 # skip null key if it exists
                 if pd.isnull(group):
                     continue
@@ -474,17 +475,21 @@ class FeatureSetCalculator(object):
                         value.index = variable_data[0].index
                     else:
                         value = pd.Series(value, index=variable_data[0].index)
-                    feature_vals.append(value)
+                    group_vals.append(value)
 
                 # Note
                 # more efficient in pandas to concat and update only once
-                if feature_vals:
+                if group_vals:
                     if f.number_output_features > 1:
-                        update_df = pd.concat(feature_vals, axis=1)
+                        update_df = pd.concat(group_vals, axis=1)
                         update_df.columns = f.get_names()
-                        frame.update(update_df)
                     else:
-                        frame[f.get_name()].update(pd.concat(feature_vals))
+                        update_df = pd.concat(group_vals)
+                        update_df.rename(f.get_name(), inplace=True)
+                feature_vals.append(update_df)
+
+            if feature_vals:
+                frame.update(pd.concat(feature_vals))
 
             progress_callback(1 / float(self.num_features))
 

--- a/featuretools/computational_backends/feature_set_calculator.py
+++ b/featuretools/computational_backends/feature_set_calculator.py
@@ -465,18 +465,24 @@ class FeatureSetCalculator(object):
                 else:
                     values = feature_func(*variable_data)
 
-                # make sure index is aligned
-                if isinstance(values, pd.Series):
-                    values.index = variable_data[0].index
-                else:
-                    values = pd.Series(values, index=variable_data[0].index)
+                if f.number_output_features == 1:
+                    values = [values]
 
-                feature_vals.append(values)
+                # make sure index is aligned
+                for value in values:
+                    if isinstance(value, pd.Series):
+                        value.index = variable_data[0].index
+                    else:
+                        value = pd.Series(value, index=variable_data[0].index)
+                    feature_vals.append(value)
 
             # Note
             # more efficient in pandas to concat and update only once
             if feature_vals:
-                frame[f.get_name()].update(pd.concat(feature_vals))
+                if f.number_output_features > 1:
+                    frame[f.get_names()].update(pd.concat(feature_vals))
+                else:
+                    frame[f.get_name()].update(pd.concat(feature_vals))
 
             progress_callback(1 / float(self.num_features))
 

--- a/featuretools/tests/primitive_tests/test_groupby_transform_primitives.py
+++ b/featuretools/tests/primitive_tests/test_groupby_transform_primitives.py
@@ -401,3 +401,26 @@ def test_serialization(es):
         ft.feature_base.GroupByTransformFeature.from_dictionary(dictionary, es,
                                                                 dependencies,
                                                                 PrimitivesDeserializer())
+
+
+def test_groupby_with_multioutput_primitive(es):
+    def multi_cum_sum(x):
+        return x.cumsum(), x.cumsum(), x.cumsum()
+
+    num_features = 3
+    MultiCumSum = make_trans_primitive(function=multi_cum_sum,
+                                       input_types=[Numeric],
+                                       return_type=Numeric,
+                                       number_output_features=num_features)
+
+    fm, _ = dfs(entityset=es,
+                target_entity="customers",
+                trans_primitives=[],
+                agg_primitives=[],
+                groupby_trans_primitives=[MultiCumSum])
+
+    for i in range(3):
+        f = 'MULTI_CUM_SUM(age) by cohort[%d]' % i
+        assert f in fm.columns
+        f = 'MULTI_CUM_SUM(age) by région_id[%d]' % i
+        assert f in fm.columns

--- a/featuretools/tests/primitive_tests/test_groupby_transform_primitives.py
+++ b/featuretools/tests/primitive_tests/test_groupby_transform_primitives.py
@@ -424,6 +424,7 @@ def test_groupby_with_multioutput_primitive(es):
         [fm['CUM_MAX(age) by cohort'], fm['CUM_MAX(age) by région_id']],
         [fm['CUM_MIN(age) by cohort'], fm['CUM_MIN(age) by région_id']]
     ]
+
     for i in range(3):
         f = 'MULTI_CUM_SUM(age) by cohort[%d]' % i
         assert f in fm.columns

--- a/featuretools/tests/primitive_tests/test_groupby_transform_primitives.py
+++ b/featuretools/tests/primitive_tests/test_groupby_transform_primitives.py
@@ -417,25 +417,19 @@ def test_groupby_with_multioutput_primitive(es):
                 target_entity='customers',
                 trans_primitives=[],
                 agg_primitives=[],
-                groupby_trans_primitives=[MultiCumSum])
+                groupby_trans_primitives=[MultiCumSum, CumSum, CumMax, CumMin])
 
-    cohort_answers = [
-        [56.0, 89.0, 25.0],
-        [56.0, 56.0, 25.0],
-        [56.0, 33.0, 25.0]
-    ]
-
-    region_answers = [
-        [56.0, 89.0, 114.0],
-        [56.0, 56.0, 56.0],
-        [56.0, 33.0, 25.0]
+    correct_answers = [
+        [fm['CUM_SUM(age) by cohort'], fm['CUM_SUM(age) by région_id']],
+        [fm['CUM_MAX(age) by cohort'], fm['CUM_MAX(age) by région_id']],
+        [fm['CUM_MIN(age) by cohort'], fm['CUM_MIN(age) by région_id']]
     ]
     for i in range(3):
         f = 'MULTI_CUM_SUM(age) by cohort[%d]' % i
         assert f in fm.columns
-        for x, y in zip(fm[f].values, cohort_answers[i]):
+        for x, y in zip(fm[f].values, correct_answers[i][0].values):
             assert x == y
         f = 'MULTI_CUM_SUM(age) by région_id[%d]' % i
         assert f in fm.columns
-        for x, y in zip(fm[f], region_answers[i]):
+        for x, y in zip(fm[f].values, correct_answers[i][1].values):
             assert x == y


### PR DESCRIPTION
### Pull Request Description
Fixes an issue that occurred when multi-output primitive was supplied as a `groupby_trans_primitives` parameter during `ft.dfs`. 

Closes issue #785.