### PR TITLE
Drop pandas 0.23

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,6 +12,7 @@ Changelog
     * Changes
         * Drop Python 2 support (:pr:`759`)
         * Add unit parameter to AvgTimeBetween (:pr:`771`)
+        * Require Pandas 0.24.1 or higher (:pr:`787`)
     * Documentation Changes
         * Update featuretools slack link (:pr:`765`)
         * Set up repo to use Read the Docs (:pr:`776`)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 scipy>=0.13.3
 numpy>=1.13.3
-pandas>=0.23.0
+pandas>=0.24.0
 tqdm>=4.32.0
 pyyaml>=3.12
 cloudpickle>=0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 scipy>=0.13.3
 numpy>=1.13.3
-pandas>=0.24.0
+pandas>=0.24.1
 tqdm>=4.32.0
 pyyaml>=3.12
 cloudpickle>=0.4.0


### PR DESCRIPTION
Increases the pandas version requirement due to lower versions no longer passing all of the unit tests

-----
*After creating the pull request: in order to pass the **changelog_updated** check you will need to update the "Future Release" section of* `docs/source/changelog.rst` *to include this pull request.*
