### PR TITLE
Fix build_docs test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,10 +153,13 @@ jobs:
           command: |
             source venv/bin/activate
             python -c "import featuretools_tsfresh_primitives"
+            # python -c "import featuretools.tsfresh"  TODO: uncomment once tsfresh supports pandas 0.24 or higher
             python -c "import featuretools_update_checker"
             python -c "import categorical_encoding"
             python -c "import nlp_primitives"
+            python -c "import featuretools.nlp_primitives"
             python -c "import autonormalize"
+            python -c "import featuretools.autonormalize"
           environment:
             FEATURETOOLS_UPDATE_CHECKER: False
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,13 +153,10 @@ jobs:
           command: |
             source venv/bin/activate
             python -c "import featuretools_tsfresh_primitives"
-            # python -c "import featuretools.tsfresh"  TODO: uncomment once tsfresh supports pandas 0.24 or higher
             python -c "import featuretools_update_checker"
             python -c "import categorical_encoding"
             python -c "import nlp_primitives"
-            # python -c "import featuretools.nlp_primitives" TODO: uncomment once nlp_primitives entrypoint is working
             python -c "import autonormalize"
-            python -c "import featuretools.autonormalize"
           environment:
             FEATURETOOLS_UPDATE_CHECKER: False
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -157,7 +157,7 @@ jobs:
             python -c "import featuretools_update_checker"
             python -c "import categorical_encoding"
             python -c "import nlp_primitives"
-            python -c "import featuretools.nlp_primitives"
+            # python -c "import featuretools.nlp_primitives" TODO: uncomment once nlp_primitives entrypoint is working
             python -c "import autonormalize"
             python -c "import featuretools.autonormalize"
           environment:

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,8 +7,8 @@ Changelog
     * Fixes
     * Changes
     * Documentation Changes
+        * Fix import error in docs (:pr:`803`)
     * Testing Changes
-        * Test more featuretools[complete] imports on CI (:pr:`803`)
 
     Thanks to the following people for contributing to this release:
     :user:`rwedge`

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,8 +8,10 @@ Changelog
     * Changes
     * Documentation Changes
     * Testing Changes
+        * Test more featuretools[complete] imports on CI (:pr:`803`)
 
     Thanks to the following people for contributing to this release:
+    :user:`rwedge`
 
 **v0.12.0 Oct 31, 2019**
     * Enhancements

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+python-dateutil==2.8.0
 scipy>=0.13.3
 numpy>=1.13.3
 pandas>=0.24.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-dateutil==2.8.0
+python-dateutil>=2.6.1,<2.8.1
 scipy>=0.13.3
 numpy>=1.13.3
 pandas>=0.24.1


### PR DESCRIPTION
### Pull Request Description
Resolves #802 

Importing `featuretools.autonormalize` fails seemingly due to pip not installing a version of python-dateutil that satisfies both pandas and botocore.
Once boto/botocore#1872 is resolved we can remove the requirement

We could add more automated tests checking that `featuretools.autonormalize` and other entrypoint imports work, but I think it would be better to test those on the original library's repo instead of ours.

I'm thinking a test scheme like this:
* Featuretools library tests that `featuretools[complete]` install the additional library
* The additional library tests the ability to use the entry point each time Featuretools master branch is updated


-----
*After creating the pull request: in order to pass the **changelog_updated** check you will need to update the "Future Release" section of* `docs/source/changelog.rst` *to include this pull request.*
