### PR TITLE
remove 2.7 from install docs

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,9 +7,11 @@ Changelog
     * Fixes
     * Changes
     * Documentation Changes
+        * remove python 2.7 support and add 3.7 in install.rst (:pr: '805')
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
+    :user:'systemshift'
 
 **v0.12.0 Oct 31, 2019**
     * Enhancements

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,11 +7,11 @@ Changelog
     * Fixes
     * Changes
     * Documentation Changes
-        * remove python 2.7 support and add 3.7 in install.rst (:pr: '805')
+        * remove python 2.7 support and add 3.7 in install.rst (:pr:`805`)
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
-    :user:'systemshift'
+    :user:`systemshift`
 
 **v0.12.0 Oct 31, 2019**
     * Enhancements

--- a/docs/source/getting_started/install.rst
+++ b/docs/source/getting_started/install.rst
@@ -1,7 +1,7 @@
 Install
 *******
 
-Featuretools is available for Python 2.7, 3.5, and 3.6. The recommended way to install Featuretools is using ``pip`` or ``conda``::
+Featuretools is available for Python 3.5, 3.6 and 3.7 The recommended way to install Featuretools is using ``pip`` or ``conda``::
 
     python -m pip install featuretools
 


### PR DESCRIPTION
### Pull Request Description
remove python 2.7 support from install.rst
based on issue #797 
-----
*After creating the pull request: in order to pass the **changelog_updated** check you will need to update the "Future Release" section of* `docs/source/changelog.rst` *to include this pull request.*
