### PR TITLE
drop python 2.7 from serialize.py

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,7 @@ Changelog
     * Enhancements
     * Fixes
     * Changes
+        * Remove python 2.7 support from serialize.py (:pr:`812`)
     * Documentation Changes
         * remove python 2.7 support and add 3.7 in install.rst (:pr:`805`)
         * Fix import error in docs (:pr:`803`)

--- a/featuretools/entityset/serialize.py
+++ b/featuretools/entityset/serialize.py
@@ -95,7 +95,6 @@ def write_entity_data(entity, path, format='csv', **kwargs):
         df = entity.df.copy()
         columns = df.select_dtypes('object').columns
         df[columns] = df[columns].astype('unicode')
-        df.columns = df.columns.astype('unicode')  # ensures string column names for python 2.7
         df.to_parquet(file, **kwargs)
     elif format == 'pickle':
         entity.df.to_pickle(file, **kwargs)


### PR DESCRIPTION
### Pull Request Description
from the discussion started in #797 and issue #808. A line to support a special case for 2.7 support has been removed.
all tests pass after removing the line.
11 warnings show, but the same number has been there before this commit.

It might be wise to investigate if the 11 warnings are exactly the same. Or if removing the line removed one warning, and a new one has replaced it.

-----
*After creating the pull request: in order to pass the **changelog_updated** check you will need to update the "Future Release" section of* `docs/source/changelog.rst` *to include this pull request.*
