### PR TITLE
use notebook version for tqdm

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 **Future Release**
     * Enhancements
     * Fixes
+        * Use tqdm.notebook instead of tqdm to solve multiple progress bar issue (:pr:`814`)
     * Changes
     * Documentation Changes
         * remove python 2.7 support and add 3.7 in install.rst (:pr:`805`)

--- a/featuretools/demo/flight.py
+++ b/featuretools/demo/flight.py
@@ -2,7 +2,7 @@ import math
 import re
 
 import pandas as pd
-from tqdm import tqdm
+from tqdm.notebook import tqdm
 
 import featuretools as ft
 import featuretools.variable_types as vtypes

--- a/featuretools/utils/gen_utils.py
+++ b/featuretools/utils/gen_utils.py
@@ -6,7 +6,7 @@ from itertools import zip_longest
 
 import s3fs
 from smart_open import open
-from tqdm import tqdm
+from tqdm.notebook import tqdm
 
 
 def session_type():


### PR DESCRIPTION
### Pull Request Description
based on  #791, tqdm shows multiple progress bars if a cell is interrupted then run again.
tqdm has a submodule to support native Jupyter: https://pypi.org/project/tqdm/#ipython-jupyter-integration
using the submodule solves the issue.

-----
*After creating the pull request: in order to pass the **changelog_updated** check you will need to update the "Future Release" section of* `docs/source/changelog.rst` *to include this pull request.*
