### PR TITLE
GitHub Action - PyPI Upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+on:
+  release:
+    types: [published]
+
+name: Release
+jobs:
+  pypi:
+    name: PyPI Release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: PyPI Upload
+      uses: FeatureLabs/gh-action-pypi-upload@master
+      env:
+        PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        TEST_PYPI_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}
+        TEST_PYPI_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 ---------
 **Future Release**
     * Enhancements
+        * Added GitHub Action to auto upload releases to PyPI (:pr:`816`)
     * Fixes
         * Fix issue with converting to pickle or parquet after adding interesting features (:pr:`798`)
     * Changes
@@ -17,7 +18,7 @@ Changelog
         * Refactor test entityset creation to avoid saving to disk (:pr:`813`)
 
     Thanks to the following people for contributing to this release:
-    :user:`rwedge`, :user:`systemshift`, :user:`frances-h`
+    :user:`rwedge`, :user:`systemshift`, :user:`frances-h`, :user:`jeff-hernandez`
 
 **v0.12.0 Oct 31, 2019**
     * Enhancements


### PR DESCRIPTION
### Pull Request Description
This adds a GitHub Action to auto upload releases to PyPI.

-----
*After creating the pull request: in order to pass the **changelog_updated** check you will need to update the "Future Release" section of* `docs/source/changelog.rst` *to include this pull request.*
