### PR TITLE
Fix global ignore variable

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,7 @@ Changelog
     * Enhancements
     * Fixes
         * Fix issue with converting to pickle or parquet after adding interesting features (:pr:`798`)
+        * Prevent DFS from creating Identity Features of globally ignored variables (:pr:`819`)
     * Changes
         * Remove python 2.7 support from serialize.py (:pr:`812`)
     * Documentation Changes

--- a/featuretools/primitives/options_utils.py
+++ b/featuretools/primitives/options_utils.py
@@ -66,7 +66,7 @@ def generate_all_primitive_options(all_primitives,
             # don't globally ignore a variable if it's included for a primitive
             if 'include_variables' in options:
                 for entity, include_vars in options['include_variables'].items():
-                    global_ignore_variables[entity] = global_ignore_variables[entity].remove(include_vars)
+                    global_ignore_variables[entity] = global_ignore_variables[entity].difference(include_vars)
             for option in options:
                 option['ignore_entities'] = option['ignore_entities'].union(
                     ignore_entities.difference(included_entities)

--- a/featuretools/primitives/options_utils.py
+++ b/featuretools/primitives/options_utils.py
@@ -50,6 +50,7 @@ def generate_all_primitive_options(all_primitives,
                       for entity in es.entities}
     primitive_options = _init_primitive_options(primitive_options, entityset_dict)
     global_ignore_entities = ignore_entities
+    global_ignore_variables = ignore_variables
     # for now, only use primitive names as option keys
     for primitive in all_primitives:
         if not isinstance(primitive, str):
@@ -62,6 +63,10 @@ def generate_all_primitive_options(all_primitives,
                 option.get('include_variables').keys() if option.get('include_variables') else set([]))
                 for option in options])
             global_ignore_entities = global_ignore_entities.difference(included_entities)
+            # don't globally ignore a variable if it's included for a primitive
+            if 'include_variables' in options:
+                for entity, include_vars in options['include_variables'].items():
+                    global_ignore_variables[entity] = global_ignore_variables[entity].remove(include_vars)
             for option in options:
                 option['ignore_entities'] = option['ignore_entities'].union(
                     ignore_entities.difference(included_entities)
@@ -81,7 +86,7 @@ def generate_all_primitive_options(all_primitives,
             # no user specified options, just use global defaults
             primitive_options[primitive] = [{'ignore_entities': ignore_entities,
                                              'ignore_variables': ignore_variables}]
-    return primitive_options, global_ignore_entities
+    return primitive_options, global_ignore_entities, global_ignore_variables
 
 
 def _init_primitive_options(primitive_options, es):

--- a/featuretools/primitives/options_utils.py
+++ b/featuretools/primitives/options_utils.py
@@ -63,11 +63,12 @@ def generate_all_primitive_options(all_primitives,
                 option.get('include_variables').keys() if option.get('include_variables') else set([]))
                 for option in options])
             global_ignore_entities = global_ignore_entities.difference(included_entities)
-            # don't globally ignore a variable if it's included for a primitive
-            if 'include_variables' in options:
-                for entity, include_vars in options['include_variables'].items():
-                    global_ignore_variables[entity] = global_ignore_variables[entity].difference(include_vars)
             for option in options:
+                # don't globally ignore a variable if it's included for a primitive
+                if 'include_variables' in option:
+                    for entity, include_vars in option['include_variables'].items():
+                        global_ignore_variables[entity] = \
+                            global_ignore_variables[entity].difference(include_vars)
                 option['ignore_entities'] = option['ignore_entities'].union(
                     ignore_entities.difference(included_entities)
                 )

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -223,13 +223,12 @@ class DeepFeatureSynthesis(object):
             primitive_options = {}
         all_primitives = self.trans_primitives + self.agg_primitives + \
             self.where_primitives + self.groupby_trans_primitives
-        self.primitive_options, self.ignore_entities =\
+        self.primitive_options, self.ignore_entities, self.ignore_variables =\
             generate_all_primitive_options(all_primitives,
                                            primitive_options,
                                            self.ignore_entities,
                                            self.ignore_variables,
                                            self.es)
-
         self.seed_features = seed_features or []
         self.drop_exact = drop_exact or []
         self.drop_contains = drop_contains or []
@@ -484,6 +483,8 @@ class DeepFeatureSynthesis(object):
         """
         variables = entity.variables
         for v in variables:
+            if v.name in self.ignore_variables[entity.id]:
+                continue
             new_f = IdentityFeature(variable=v)
             self._handle_new_feature(all_features=all_features,
                                      new_feature=new_f)

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -1030,7 +1030,7 @@ def test_primitive_options_with_globals(es):
 
     # non-overlapping ignore_variables
     options = {'num_unique': {'ignore_variables': {'customers': ['engagement_level']}}}
-    dfs_obj = DeepFeatureSynthesis(target_entity_id='cohorts',
+    dfs_obj = DeepFeatureSynthesis(target_entity_id='customers',
                                    entityset=es,
                                    ignore_variables={'customers': [u'région_id']},
                                    primitive_options=options)
@@ -1040,8 +1040,9 @@ def test_primitive_options_with_globals(es):
         entities = [d.entity.id for d in deps]
         identities = [d for d in deps if isinstance(d, IdentityFeature)]
         variables = [d.variable.id for d in identities]
+        assert f.get_name() != u'région_id'
         if 'customers' in entities:
-            assert u'region_id' not in variables
+            assert u'région_id' not in variables
         if isinstance(f.primitive, NumUnique):
             if 'customers' in entities:
                 assert 'engagement_level' not in variables
@@ -1067,6 +1068,7 @@ def test_primitive_options_with_globals(es):
         entities = [d.entity.id for d in deps]
         identities = [d for d in deps if isinstance(d, IdentityFeature)]
         variables = [d.variable.id for d in identities]
+        assert f.get_name() != 'customers.age'
         if isinstance(f.primitive, Mode):
             assert 'sessions' in entities or 'customers' in entities
             if 'customers' in entities:

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -1084,7 +1084,8 @@ def test_primitive_options_with_globals(es):
         else:
             assert 'sessions' not in entities
             if 'customers' in entities:
-                assert 'age' not in variables
+                for variable in [v for v in variables if isinstance(v, IdentityFeature)]:
+                    assert 'age' != variable.get_name()
 
 
 def test_primitive_options_groupbys(es):

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -1051,7 +1051,8 @@ def test_primitive_options_with_globals(es):
     options = {'mode': {'include_entities': ['sessions', 'customers'],
                         'ignore_variables': {'customers': [u'région_id']}},
                'num_unique': {'include_entities': ['sessions', 'customers'],
-                              'include_variables': {'sessions': ['device_type']}},
+                              'include_variables': {'sessions': ['device_type'],
+                                                    'customers': ['age']}},
                'month': {'ignore_variables': {'cohorts': ['cohort_end']}}}
     dfs_obj = DeepFeatureSynthesis(target_entity_id='cohorts',
                                    entityset=es,
@@ -1068,7 +1069,6 @@ def test_primitive_options_with_globals(es):
         entities = [d.entity.id for d in deps]
         identities = [d for d in deps if isinstance(d, IdentityFeature)]
         variables = [d.variable.id for d in identities]
-        assert f.get_name() != 'customers.age'
         if isinstance(f.primitive, Mode):
             assert 'sessions' in entities or 'customers' in entities
             if 'customers' in entities:
@@ -1078,6 +1078,8 @@ def test_primitive_options_with_globals(es):
             assert 'sessions' in entities or 'customers' in entities
             if 'sessions' in entities:
                 assert 'device_type' in variables or variables == []
+            if 'customers' in entities:
+                assert 'age' in variables or variables == []
         # All other primitives ignore 'sessions' and 'age'
         else:
             assert 'sessions' not in entities


### PR DESCRIPTION
Globally ignores a variable (including preventing Identity Feature from being created) if global options do not conflict with any primitive options

-----
*After creating the pull request: in order to pass the **changelog_updated** check you will need to update the "Future Release" section of* `docs/source/changelog.rst` *to include this pull request.*
