### PR TITLE
Use pd.Series.empty for faster check

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,7 +6,7 @@ Changelog
     * Enhancements
         * Added GitHub Action to auto upload releases to PyPI (:pr:`816`)
     * Fixes
-        * Fix issue with converting to pickle or parquet after adding interesting features (:pr:`798`)
+        * Fix issue with converting to pickle or parquet after adding interesting features (:pr:`798`, :pr:`823`)
     * Changes
         * Remove python 2.7 support from serialize.py (:pr:`812`)
     * Documentation Changes

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -1,8 +1,6 @@
 import logging
 from collections import defaultdict
 
-import pandas as pd
-
 from featuretools import primitives, variable_types
 from featuretools.entityset.relationship import RelationshipPath
 from featuretools.feature_base import (
@@ -517,7 +515,7 @@ class DeepFeatureSynthesis(object):
             # Features can contain a stale EntitySet reference without
             # interesting_values
             variable = self.es[feat.variable.entity.id][feat.variable.id]
-            if variable.interesting_values.equals(pd.Series()):
+            if variable.interesting_values.empty:
                 continue
 
             for val in variable.interesting_values:


### PR DESCRIPTION
* use pd.Series.empty instead of .equals(pd.Series())
-----
*After creating the pull request: in order to pass the **changelog_updated** check you will need to update the "Future Release" section of* `docs/source/changelog.rst` *to include this pull request.*
