### PR TITLE
remove botocore and boto3 restrictions in test reqs

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,7 @@ Changelog
     * Documentation Changes
     * Testing Changes
         * Run unit tests in windows environment (:pr:`790`)
+        * Update boto3 version requirement for tests (:pr:`838`)
 
     Thanks to the following people for contributing to this release:
     :user:`rwedge`, :user:`systemshift`, :user:`jeffzi`, :user:`kmax12`

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,8 +4,6 @@ pytest-xdist==1.26.1
 pytest-cov==2.6.1
 fastparquet>=0.1.6
 graphviz>=0.8.4
-botocore<=1.13.8
-boto3<=1.10.8
 moto>=1.3.13
 smart-open>=1.8.4
 s3fs>=0.2.2

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -7,3 +7,4 @@ graphviz>=0.8.4
 moto>=1.3.13
 smart-open>=1.8.4
 s3fs>=0.2.2
+boto3>=1.10.45


### PR DESCRIPTION
With today's release of botocore the python-dateutil error should be gone so we can let our dependencies use the latest boto3/botocore
