### PR TITLE
Pin msgpack for Python 3.5

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,13 @@
 
 Changelog
 ---------
+**Future Release**
+    * Changes
+        * Pin msgpack dependency for Python 3.5; remove dataframe from Dask dependency (:pr:`851`)
+
+    Thanks to the following people for contributing to this release:
+    :user:`frances-h`
+
 **v0.13.2 Jan 31, 2020**
     * Enhancements
         * Support for Pandas 1.0.0 (:pr:`844`)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ distributed>=1.24.2
 dask[dataframe]>=1.1.0
 psutil>=5.4.8
 click>=7.0.0
+msgpack<1.0.0; python_version == '3.5'

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ tqdm>=4.32.0
 pyyaml>=3.12
 cloudpickle>=0.4.0
 distributed>=1.24.2
-dask[dataframe]>=1.1.0
+dask>=1.1.0
 psutil>=5.4.8
 click>=7.0.0
 msgpack<1.0.0; python_version == '3.5'


### PR DESCRIPTION
Dask `distributed` runs into issues with the `msgpack` 1.0.0 release on Python 3.5. Dask no longer supports Python 3.5, so their fix for the `msgpack` update does not get applied to Python 3.5. This pins `msgpack` to before the 1.0.0 release on Python 3.5 to avoid the issue. 

Dask `distributed` required dataframe dependencies for a check where the full dependency was not needed. Dask has updated, so the additional dataframe dependencies are no longer required for `distributed` to work correctly with Featuretools
