### PR TITLE
For n_jobs, close client before tearing down cluster

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3,11 +3,13 @@
 Changelog
 ---------
 **Future Release**
+    * Fixes
+        * Fix a connection closed error when using n_jobs (:pr:`853`)
     * Changes
         * Pin msgpack dependency for Python 3.5; remove dataframe from Dask dependency (:pr:`851`)
 
     Thanks to the following people for contributing to this release:
-    :user:`frances-h`
+    :user:`frances-h`, :user:`rwedge`
 
 **v0.13.2 Jan 31, 2020**
     * Enhancements

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -591,11 +591,11 @@ def parallel_calculate_chunks(cutoff_time, chunk_size, feature_set, approximate,
     except Exception:
         raise
     finally:
-        if 'cluster' not in dask_kwargs and cluster is not None:
-            cluster.close()
-
         if client is not None:
             client.close()
+
+        if 'cluster' not in dask_kwargs and cluster is not None:
+            cluster.close()
 
     feature_matrix = pd.concat(feature_matrix)
 


### PR DESCRIPTION
Should fix #852

Shutting down the dask scheduler before the client occasionally caused "Connection closed" errors to pop up.  Shutting down the client first seems to resolve this problem.