### PR TITLE
Update help link in Github issue template

### DIFF
--- a/docs/issue_template.md
+++ b/docs/issue_template.md
@@ -2,7 +2,7 @@
 (replace this text with your issue)
 
 -----
-*Issues created here on Github are for bugs or feature requests. For usage questions and questions about errors, please ask on Stack Overflow with the [featuretools](https://stackoverflow.com/questions/tagged/featuretools) tag. Check the [documentation](https://docs.featuretools.com/#get-help) for further guidance on where to ask your question.*
+*Issues created here on Github are for bugs or feature requests. For usage questions and questions about errors, please ask on Stack Overflow with the [featuretools](https://stackoverflow.com/questions/tagged/featuretools) tag. Check the [documentation](https://docs.featuretools.com/en/stable/help.html) for further guidance on where to ask your question.*
 
 
 #### Bug/Feature Request Description

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,8 @@ Changelog
         * Fix a connection closed error when using n_jobs (:pr:`853`)
     * Changes
         * Pin msgpack dependency for Python 3.5; remove dataframe from Dask dependency (:pr:`851`)
+    * Documentation Changes
+        * Update link to help documentation page in Github issue template (:pr:`855`)
 
     Thanks to the following people for contributing to this release:
     :user:`frances-h`, :user:`rwedge`


### PR DESCRIPTION
The issue template on Github has an out of date docs link