### PR TITLE
Add doc links to primitives.featurelabs.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,9 @@ customer_id                                                                     
 
 [5 rows x 69 columns]
 ```
-We now have a feature vector for each customer that can be used for machine learning. See the [documentation on Deep Feature Synthesis](https://docs.featuretools.com/automated_feature_engineering/afe.html) for more examples.
+We now have a feature vector for each customer that can be used for machine learning. See the [documentation on Deep Feature Synthesis](https://docs.featuretools.com/automated_feature_engineering/afe.html) for more examples. 
+
+Featuretools contains many [different types of built-in primitives](https://primitives.featurelabs.com/) for creating features. If the primitive you need is not included, Featuretools also allows you to [define your own custom primitives](https://docs.featuretools.com/en/stable/automated_feature_engineering/primitives.html#defining-custom-primitives).
 
 ## Demos
 **Predict Next Purchase**

--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -63,6 +63,8 @@ Time utils
 
 Feature Primitives
 ~~~~~~~~~~~~~~~~~~
+A list of all Featuretools primitives can be obtained by visiting `primitives.featurelabs.com <https://primitives.featurelabs.com/>`__.
+
 Primitive Types
 ---------------
 .. currentmodule:: featuretools.primitives

--- a/docs/source/automated_feature_engineering/primitives.rst
+++ b/docs/source/automated_feature_engineering/primitives.rst
@@ -62,7 +62,7 @@ In the example above, we use two types of primitives.
 
 **Transform primitives:** These primitives take one or more variables from an entity as an input and output a new variable for that entity. They are applied to a single entity. E.g: ``"hour"``, ``"time_since_previous"``, ``"absolute"``.
 
-For a DataFrame that lists and describes each built-in primitive in Featuretools, call ``ft.list_primitives()``.
+For a DataFrame that lists and describes each built-in primitive in Featuretools, call ``ft.list_primitives()``.  In addition, a list of all available primitives can be obtained by visiting `primitives.featurelabs.com <https://primitives.featurelabs.com/>`__.
 
 
 .. ipython:: python

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,13 @@
 
 Changelog
 ---------
+**Future Release**
+    * Documentation Changes
+        * Add links to primitives.featurelabs.com (:pr:`860`)
+
+    Thanks to the following people for contributing to this release:
+    :user:`thehomebrewnerd`
+
 **v0.13.3 Feb 28, 2020**
     * Fixes
         * Fix a connection closed error when using n_jobs (:pr:`853`)

--- a/docs/source/featuretools_enterprise.rst
+++ b/docs/source/featuretools_enterprise.rst
@@ -5,7 +5,7 @@ Featuretools Enterprise
 
 Premium Primitives
 ------------------
-Feature primitives are the building blocks of Featuretools. They define individual computations that can be applied to raw datasets to create new features. Featuretools Enterprise contains over 100 domain-specific premium primitives to help you build better features for more accurate models.
+Feature primitives are the building blocks of Featuretools. They define individual computations that can be applied to raw datasets to create new features. Featuretools Enterprise contains over 100 domain-specific premium primitives to help you build better features for more accurate models. A list of all premium primitives can be obtained by visiting `primitives.featurelabs.com <https://primitives.featurelabs.com/>`__.
 
 
 Spark and Dask

--- a/docs/source/frequently_asked_questions.ipynb
+++ b/docs/source/frequently_asked_questions.ipynb
@@ -1509,7 +1509,7 @@
    "source": [
     "### How do I get a list of all Aggregation and Transform primitives?\n",
     "\n",
-    "You can do `featuretools.list_primitives()` to get all the primitive in Featuretools. It will return a Dataframe with the names, type, and description of the primitives."
+    "You can do `featuretools.list_primitives()` to get all the primitive in Featuretools. It will return a Dataframe with the names, type, and description of the primitives. You can also visit [primitives.featurelabs.com](https://primitives.featurelabs.com/) to obtain a list of all available primitives."
    ]
   },
   {
@@ -2031,7 +2031,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.4"
   },
   "mimetype": "text/x-python",
   "name": "python",

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -179,6 +179,7 @@ Table of contents
    usage_tips/glossary
    ecosystem
    api_reference
+   Primitive Reference <https://primitives.featurelabs.com/>
    changelog
 
 


### PR DESCRIPTION
### Add links to primitives.featurelabs.com
Closes Issue #858 

Added links in
-`README.md`
-Feature Primitives documentation page
-Primitives FAQ page
-Featuretools Enterprise page
-API Reference
-Sidebar
