### PR TITLE
Make installed packages check case insensitive

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,9 +5,11 @@ Changelog
 **Future Release**
     * Documentation Changes
         * Add links to primitives.featurelabs.com (:pr:`860`)
+    * Testing Changes
+        * Miscellaneous changes (:pr:`861`)
 
     Thanks to the following people for contributing to this release:
-    :user:`thehomebrewnerd`
+    :user:`rwedge`, :user:`thehomebrewnerd`
 
 **v0.13.3 Feb 28, 2020**
     * Fixes

--- a/featuretools/tests/utils_tests/test_cli_utils.py
+++ b/featuretools/tests/utils_tests/test_cli_utils.py
@@ -25,11 +25,15 @@ def test_sys_info():
 
 def test_installed_packages():
     installed_packages = get_installed_packages()
+    # Per PEP 426, package names are case insensitive
+    # Underscore and hyphen are equivalent
+    installed_set = {name.lower().replace('-', '_')
+                     for name in installed_packages.keys()}
     requirements = ["pandas", "numpy", "tqdm",
-                    "PyYAML", "cloudpickle",
+                    "pyyaml", "cloudpickle",
                     "dask", "distributed", "psutil",
-                    "Click"]
-    assert set(requirements).issubset(installed_packages.keys())
+                    "click"]
+    assert set(requirements).issubset(installed_set)
 
 
 def test_get_featuretools_root(this_dir):


### PR DESCRIPTION
One of our tests related to the `featuretools info` command broke when a package changed the capitalization of its name.  Package names are supposed to be case insensitive, so this PR updates the test to convert to lower case characters and replace hyphens with underscores.
