### PR TITLE
Add viewcode Sphinx extension

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 **Future Release**
     * Documentation Changes
         * Add links to primitives.featurelabs.com (:pr:`860`)
+        * Add source code links to API reference (:pr:`862`)
     * Testing Changes
         * Miscellaneous changes (:pr:`861`)
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,7 +39,8 @@ extensions = [
     'nbsphinx',
     'IPython.sphinxext.ipython_console_highlighting',
     'IPython.sphinxext.ipython_directive',
-    'sphinx.ext.extlinks'
+    'sphinx.ext.extlinks',
+    'sphinx.ext.viewcode',
 ]
 
 


### PR DESCRIPTION
### Add `viewcode` Sphinx extension

Added the `viewcode` Sphinx extension to add links to source code in API reference docs.

Closes #800 