### PR TITLE
Add pip to test-requirements.txt

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,7 +6,7 @@ Changelog
     * Fixes
         * Fix ft.show_info() not displaying in Jupyter notebooks (:pr:`863`)
     * Changes
-        * Added Plugin Warnings at Entry Point (:pr:`850`)
+        * Added Plugin Warnings at Entry Point (:pr:`850`, :pr:`869`)
     * Documentation Changes
         * Add links to primitives.featurelabs.com (:pr:`860`)
         * Add source code links to API reference (:pr:`862`)
@@ -16,7 +16,7 @@ Changelog
         * Miscellaneous changes (:pr:`861`)
 
     Thanks to the following people for contributing to this release:
-    :user:`FreshLeaf8865`, :user:`jeff-hernandez`, :user:`rwedge`, :user:`thehomebrewnerd`
+    :user:`FreshLeaf8865`, :user:`jeff-hernandez`, :user:`rwedge`, :user:`thehomebrewnerd`, :user:`frances-h`
 
 **v0.13.3 Feb 28, 2020**
     * Fixes

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,4 @@
-pip
+pip>=20.0.2
 pytest==5.2.0
 pympler==0.5
 pytest-xdist==1.26.1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
+pip
 pytest==5.2.0
 pympler==0.5
 pytest-xdist==1.26.1


### PR DESCRIPTION
Adds `pip` to `test-requirements.txt` for the plugin warning tests