### PR TITLE
Use uint8 dtype for one hot encoded features

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -3,6 +3,8 @@
 Changelog
 ---------
 **Future Release**
+    * Enhancements
+        * ft.encode_features - use less memory for one-hot encoded columns (:pr:`876`)
     * Fixes
         * Use logger.warning to fix deprecated logger.warn (:pr:`871`)
     * Changes
@@ -11,7 +13,7 @@ Changelog
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`
+    :user:`gsheni`, :user:`rwedge`
 
 **v0.13.4 Mar 27, 2020**
     .. warning::

--- a/featuretools/synthesis/encode_features.py
+++ b/featuretools/synthesis/encode_features.py
@@ -133,12 +133,12 @@ def encode_features(feature_matrix, features, top_n=DEFAULT_TOP_N, include_unkno
         for label in unique:
             add = f == label
             encoded.append(add)
-            X[add.get_name()] = (X[f.get_name()] == label).astype(int)
+            X[add.get_name()] = (X[f.get_name()] == label).astype("uint8")
 
         if include_unknown:
             unknown = f.isin(unique).NOT().rename(f.get_name() + " is unknown")
             encoded.append(unknown)
-            X[unknown.get_name()] = (~X[f.get_name()].isin(unique)).astype(int)
+            X[unknown.get_name()] = (~X[f.get_name()].isin(unique)).astype("uint8")
 
         X.drop(f.get_name(), axis=1, inplace=True)
 


### PR DESCRIPTION
Resolves #875 .

Changes the dtype used for the one-hot encoded feature columns in `encode_features` to use the same dtype as `pandas.get_dummies`