### PR TITLE
Fix issue with make_index and Dask entities

### DIFF
--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -562,7 +562,13 @@ def _create_index(index, make_index, df):
                            "integer column", index)
         # Case 5: make_index with no errors or warnings
         # (Case 4 also uses this code path)
-        df.insert(0, index, range(0, len(df)))
+        if isinstance(df, dd.core.DataFrame):
+            df_cols = df.columns.to_list()
+            df[index] = 1
+            df[index] = df[index].cumsum() - 1
+            df = df[[index] + df_cols]
+        else:
+            df.insert(0, index, range(len(df)))
         created_index = index
     # Case 6: user specified index, which is already in df. No action needed.
     return created_index, index, df

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -563,10 +563,8 @@ def _create_index(index, make_index, df):
         # Case 5: make_index with no errors or warnings
         # (Case 4 also uses this code path)
         if isinstance(df, dd.core.DataFrame):
-            df_cols = df.columns.to_list()
             df[index] = 1
             df[index] = df[index].cumsum() - 1
-            df = df[[index] + df_cols]
         else:
             df.insert(0, index, range(len(df)))
         created_index = index

--- a/featuretools/tests/entityset_tests/test_dask.py
+++ b/featuretools/tests/entityset_tests/test_dask.py
@@ -1,14 +1,9 @@
-from datetime import datetime
-
+import dask.dataframe as dd
 import pandas as pd
 import pytest
-from dask import dataframe as dd
 
 import featuretools as ft
-from featuretools import calculate_feature_matrix
 from featuretools.entityset import EntitySet, Relationship
-from featuretools.feature_base import DirectFeature
-from featuretools.primitives import Count
 
 
 def test_transform(es, dask_es):
@@ -202,11 +197,12 @@ def test_add_last_time_indexes():
 def test_create_entity_with_make_index():
     df = pd.DataFrame({"values": [1, 12, -34, 27]})
     dask_df = dd.from_pandas(df, npartitions=2)
-
     dask_es = EntitySet(id="dask_es")
     vtypes = {"values": ft.variable_types.Numeric}
     dask_es.entity_from_dataframe(entity_id="new_entity", dataframe=dask_df, make_index=True, index="new_index", variable_types=vtypes)
-    breakpoint()
+
+    assert dask_es['new_entity'].df.columns[0] == "new_index"
+    assert dask_es['new_entity'].df['new_index'].compute().to_list() == [0, 1, 2, 3]
 
 
 def test_single_table_dask_entityset():

--- a/featuretools/tests/entityset_tests/test_dask.py
+++ b/featuretools/tests/entityset_tests/test_dask.py
@@ -11,70 +11,70 @@ from featuretools.feature_base import DirectFeature
 from featuretools.primitives import Count
 
 
-# def test_transform(es, dask_es):
-#     primitives = ft.list_primitives()
-#     trans_list = primitives[primitives['type'] == 'transform']['name'].tolist()
-#     # These primitives currently not supported with Dask
-#     not_supported = ['cum_mean', 'equal', 'not_equal', 'equal_scalar', 'not_equal_scalar']
-#     trans_primitives = [prim for prim in trans_list if prim not in not_supported]
-#     agg_primitives = []
+def test_transform(es, dask_es):
+    primitives = ft.list_primitives()
+    trans_list = primitives[primitives['type'] == 'transform']['name'].tolist()
+    # These primitives currently not supported with Dask
+    not_supported = ['cum_mean', 'equal', 'not_equal', 'equal_scalar', 'not_equal_scalar']
+    trans_primitives = [prim for prim in trans_list if prim not in not_supported]
+    agg_primitives = []
 
-#     assert es == dask_es
+    assert es == dask_es
 
-#     # Run DFS using each entity as a target and confirm results match
-#     for entity in es.entities:
-#         fm, _ = ft.dfs(entityset=es,
-#                        target_entity=entity.id,
-#                        trans_primitives=trans_primitives,
-#                        agg_primitives=agg_primitives,
-#                        cutoff_time=pd.Timestamp("2019-01-05 04:00"),
-#                        max_depth=2,
-#                        max_features=100)
+    # Run DFS using each entity as a target and confirm results match
+    for entity in es.entities:
+        fm, _ = ft.dfs(entityset=es,
+                       target_entity=entity.id,
+                       trans_primitives=trans_primitives,
+                       agg_primitives=agg_primitives,
+                       cutoff_time=pd.Timestamp("2019-01-05 04:00"),
+                       max_depth=2,
+                       max_features=100)
 
-#         dask_fm, _ = ft.dfs(entityset=dask_es,
-#                             target_entity=entity.id,
-#                             trans_primitives=trans_primitives,
-#                             agg_primitives=agg_primitives,
-#                             cutoff_time=pd.Timestamp("2019-01-05 04:00"),
-#                             max_depth=2,
-#                             max_features=100)
-#         # Use the same columns and make sure both indexes are sorted the same
-#         dask_computed_fm = dask_fm.compute().set_index(entity.index).loc[fm.index][fm.columns]
-#         pd.testing.assert_frame_equal(fm, dask_computed_fm)
+        dask_fm, _ = ft.dfs(entityset=dask_es,
+                            target_entity=entity.id,
+                            trans_primitives=trans_primitives,
+                            agg_primitives=agg_primitives,
+                            cutoff_time=pd.Timestamp("2019-01-05 04:00"),
+                            max_depth=2,
+                            max_features=100)
+        # Use the same columns and make sure both indexes are sorted the same
+        dask_computed_fm = dask_fm.compute().set_index(entity.index).loc[fm.index][fm.columns]
+        pd.testing.assert_frame_equal(fm, dask_computed_fm)
 
 
-# def test_aggregation(es, dask_es):
-#     primitives = ft.list_primitives()
-#     trans_primitives = []
-#     agg_list = primitives[primitives['type'] == 'aggregation']['name'].tolist()
-#     not_supported = ['trend', 'first', 'last', 'time_since_first', 'time_since_last']
-#     agg_primitives = [prim for prim in agg_list if prim not in not_supported]
+def test_aggregation(es, dask_es):
+    primitives = ft.list_primitives()
+    trans_primitives = []
+    agg_list = primitives[primitives['type'] == 'aggregation']['name'].tolist()
+    not_supported = ['trend', 'first', 'last', 'time_since_first', 'time_since_last']
+    agg_primitives = [prim for prim in agg_list if prim not in not_supported]
 
-#     assert es == dask_es
+    assert es == dask_es
 
-#     # Run DFS using each entity as a target and confirm results match
-#     for entity in es.entities:
-#         # remove n_most_common for customers due to ambiguity
-#         if entity.id == 'customers':
-#             agg_primitives.remove('n_most_common')
-#         fm, _ = ft.dfs(entityset=es,
-#                        target_entity=entity.id,
-#                        trans_primitives=trans_primitives,
-#                        agg_primitives=agg_primitives,
-#                        cutoff_time=pd.Timestamp("2019-01-05 04:00"),
-#                        max_depth=2)
+    # Run DFS using each entity as a target and confirm results match
+    for entity in es.entities:
+        # remove n_most_common for customers due to ambiguity
+        if entity.id == 'customers':
+            agg_primitives.remove('n_most_common')
+        fm, _ = ft.dfs(entityset=es,
+                       target_entity=entity.id,
+                       trans_primitives=trans_primitives,
+                       agg_primitives=agg_primitives,
+                       cutoff_time=pd.Timestamp("2019-01-05 04:00"),
+                       max_depth=2)
 
-#         dask_fm, _ = ft.dfs(entityset=dask_es,
-#                             target_entity=entity.id,
-#                             trans_primitives=trans_primitives,
-#                             agg_primitives=agg_primitives,
-#                             cutoff_time=pd.Timestamp("2019-01-05 04:00"),
-#                             max_depth=2)
-#         if entity.id == 'customers':
-#             agg_primitives.append('n_most_common')
-#         # Use the same columns and make sure both indexes are sorted the same
-#         dask_computed_fm = dask_fm.compute().set_index(entity.index).loc[fm.index][fm.columns]
-#         pd.testing.assert_frame_equal(fm, dask_computed_fm, check_dtype=False)
+        dask_fm, _ = ft.dfs(entityset=dask_es,
+                            target_entity=entity.id,
+                            trans_primitives=trans_primitives,
+                            agg_primitives=agg_primitives,
+                            cutoff_time=pd.Timestamp("2019-01-05 04:00"),
+                            max_depth=2)
+        if entity.id == 'customers':
+            agg_primitives.append('n_most_common')
+        # Use the same columns and make sure both indexes are sorted the same
+        dask_computed_fm = dask_fm.compute().set_index(entity.index).loc[fm.index][fm.columns]
+        pd.testing.assert_frame_equal(fm, dask_computed_fm, check_dtype=False)
 
 
 def test_create_entity_from_dask_df(es):
@@ -197,6 +197,16 @@ def test_add_last_time_indexes():
     dask_es.add_last_time_indexes()
 
     pd.testing.assert_series_equal(es['sessions'].last_time_index.sort_index(), dask_es['sessions'].last_time_index.compute())
+
+
+def test_create_entity_with_make_index():
+    df = pd.DataFrame({"values": [1, 12, -34, 27]})
+    dask_df = dd.from_pandas(df, npartitions=2)
+
+    dask_es = EntitySet(id="dask_es")
+    vtypes = {"values": ft.variable_types.Numeric}
+    dask_es.entity_from_dataframe(entity_id="new_entity", dataframe=dask_df, make_index=True, index="new_index", variable_types=vtypes)
+    breakpoint()
 
 
 def test_single_table_dask_entityset():

--- a/featuretools/tests/entityset_tests/test_dask.py
+++ b/featuretools/tests/entityset_tests/test_dask.py
@@ -195,14 +195,15 @@ def test_add_last_time_indexes():
 
 
 def test_create_entity_with_make_index():
-    df = pd.DataFrame({"values": [1, 12, -34, 27]})
+    values = [1, 12, -23, 27]
+    df = pd.DataFrame({"values": values})
     dask_df = dd.from_pandas(df, npartitions=2)
     dask_es = EntitySet(id="dask_es")
     vtypes = {"values": ft.variable_types.Numeric}
     dask_es.entity_from_dataframe(entity_id="new_entity", dataframe=dask_df, make_index=True, index="new_index", variable_types=vtypes)
 
-    assert dask_es['new_entity'].df.columns[0] == "new_index"
-    assert dask_es['new_entity'].df['new_index'].compute().to_list() == [0, 1, 2, 3]
+    expected_df = pd.DataFrame({"new_index": range(len(values)), "values": values})
+    pd.testing.assert_frame_equal(expected_df, dask_es['new_entity'].df.compute())
 
 
 def test_single_table_dask_entityset():


### PR DESCRIPTION
Update `entity.py` to allow usage of the `make_index` parameter when creating an entity from a Dask dataframe.

Fixes #894 