### PR TITLE
Update set_time_index code path for Dask dataframes and impacted test

### DIFF
--- a/featuretools/tests/entityset_tests/test_dask.py
+++ b/featuretools/tests/entityset_tests/test_dask.py
@@ -606,7 +606,7 @@ def test_build_es_from_scratch_and_run_dfs():
         "amount": ft.variable_types.Numeric,
         "customer_id": ft.variable_types.Id,
         "device": ft.variable_types.Categorical,
-        "session_start": ft.variable_types.DatetimeTimeIndex,
+        "session_start": ft.variable_types.Datetime,
         "zip_code": ft.variable_types.ZIPCode,
         "join_date": ft.variable_types.Datetime,
         "date_of_birth": ft.variable_types.Datetime

--- a/featuretools/tests/entityset_tests/test_dask.py
+++ b/featuretools/tests/entityset_tests/test_dask.py
@@ -650,20 +650,17 @@ def test_build_es_from_scratch_and_run_dfs():
 
     trans_primitives = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
     agg_primitives = ['num_unique', 'count', 'max', 'sum']
-    groupby_trans_primitives = ['cum_sum', 'diff']
 
     fm, _ = ft.dfs(entityset=es,
                    target_entity="customers",
                    trans_primitives=trans_primitives,
                    agg_primitives=agg_primitives,
-                   groupby_trans_primitives=groupby_trans_primitives,
                    max_depth=2)
 
     dask_fm, _ = ft.dfs(entityset=dask_es,
                         target_entity="customers",
                         trans_primitives=trans_primitives,
                         agg_primitives=agg_primitives,
-                        groupby_trans_primitives=groupby_trans_primitives,
                         max_depth=2)
 
     # Use the same columns and make sure both have same index sorting

--- a/featuretools/tests/entityset_tests/test_dask.py
+++ b/featuretools/tests/entityset_tests/test_dask.py
@@ -648,7 +648,8 @@ def test_build_es_from_scratch_and_run_dfs():
                                        make_time_index="join_date",
                                        additional_variables=["zip_code", "join_date", "date_of_birth"])
 
-    trans_primitives = ['cum_sum', 'diff', 'absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
+    # trans_primitives = ['cum_sum', 'diff', 'absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
+    trans_primitives = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
     agg_primitives = ['num_unique', 'count', 'max', 'sum']
 
     fm, _ = ft.dfs(entityset=es,
@@ -664,5 +665,5 @@ def test_build_es_from_scratch_and_run_dfs():
                         max_depth=2)
 
     # Use the same columns and make sure both have same index sorting
-
-    pd.testing.assert_frame_equal(fm, dask_fm.compute().set_index('customer_id')[fm.columns], check_dtype=False)
+    _dask_fm = dask_fm.compute().set_index('customer_id').reindex(fm.index)
+    pd.testing.assert_frame_equal(fm, _dask_fm[fm.columns], check_dtype=False)

--- a/featuretools/tests/entityset_tests/test_dask.py
+++ b/featuretools/tests/entityset_tests/test_dask.py
@@ -648,20 +648,22 @@ def test_build_es_from_scratch_and_run_dfs():
                                        make_time_index="join_date",
                                        additional_variables=["zip_code", "join_date", "date_of_birth"])
 
-    # trans_primitives = ['cum_sum', 'diff', 'absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
     trans_primitives = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
     agg_primitives = ['num_unique', 'count', 'max', 'sum']
+    groupby_trans_primitives = ['cum_sum', 'diff']
 
     fm, _ = ft.dfs(entityset=es,
                    target_entity="customers",
                    trans_primitives=trans_primitives,
                    agg_primitives=agg_primitives,
+                   groupby_trans_primitives=groupby_trans_primitives,
                    max_depth=2)
 
     dask_fm, _ = ft.dfs(entityset=dask_es,
                         target_entity="customers",
                         trans_primitives=trans_primitives,
                         agg_primitives=agg_primitives,
+                        groupby_trans_primitives=groupby_trans_primitives,
                         max_depth=2)
 
     # Use the same columns and make sure both have same index sorting


### PR DESCRIPTION
Fixes #913 

This PR updates `Entity.set_time_index` so that Dask dataframes do not exit the function early.  Specific points in the code where costly validation checks occur have different logic for Dask frames.

This is necessary to fix the `test_build_es_from_scratch_and_run_dfs` test.
For that test, I also changed the logic to get the two dataframe indexes to match and removed two primitives that have the `uses_full_entity` attribute.  Features using these primitives were returning different values, which I think is happening because the dask entity data is not sorted