### PR TITLE
Update premium primitives test to use python 3.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,15 +110,15 @@ jobs:
       - image: circleci/buildpack-deps:curl
     steps:
       - run:
-          name: "Trigger premium primitives tests for python 3.5"
-          command: "curl -u ${PP_K}: -d build_parameters[CIRCLE_JOB]=python-35 https://circleci.com/api/v1.1/project/github/FeatureLabs/premium-primitives/tree/master"
+          name: "Trigger premium primitives tests for python 3.6"
+          command: "curl -u ${PP_K}: -d build_parameters[CIRCLE_JOB]=python-36 https://circleci.com/api/v1.1/project/github/FeatureLabs/premium-primitives/tree/master"
   run_premium_primitives_tests_on_release:
     docker:
       - image: circleci/buildpack-deps:curl
     steps:
       - run:
-          name: "Trigger premium primitives tests for python 3.5 release"
-          command: "curl -u ${PP_K}: -d build_parameters[CIRCLE_JOB]=python-35-ft-release https://circleci.com/api/v1.1/project/github/FeatureLabs/premium-primitives/tree/master"
+          name: "Trigger premium primitives tests for python 3.6 release"
+          command: "curl -u ${PP_K}: -d build_parameters[CIRCLE_JOB]=python-36-ft-release https://circleci.com/api/v1.1/project/github/FeatureLabs/premium-primitives/tree/master"
 
   unit_tests:
     working_directory: ~/featuretools

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,7 @@ Changelog
     * Fixes
         * Use logger.warning to fix deprecated logger.warn (:pr:`871`)
     * Changes
+        * Change premium primitives CI test to Python 3.6 (:pr:`916`)
         * Remove Python 3.5 support (:pr:`917`)
     * Documentation Changes
         * Fix README links to docs (:pr:`872`)


### PR DESCRIPTION
### Pull Request Description
- Update premium primitives test to use python 3.6 test