### PR TITLE
Update dask tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
           command: |
               C:\Users\circleci\Miniconda3\shell\condabin\conda-hook.ps1
               conda activate featuretools
-              pytest featuretools\
+              pytest featuretools\ --ignore=featuretools\dask-tests-tmp\
   install_ft:
     working_directory: ~/featuretools
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
           command: |
               C:\Users\circleci\Miniconda3\shell\condabin\conda-hook.ps1
               conda activate featuretools
-              pytest featuretools\ --ignore=featuretools\dask-tests-tmp\
+              pytest featuretools\ -n 2
   install_ft:
     working_directory: ~/featuretools
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
           command: |
               C:\Users\circleci\Miniconda3\shell\condabin\conda-hook.ps1
               conda activate featuretools
-              pytest featuretools\ -n 2
+              pytest featuretools\ -n 2 --ignore=featuretools\dask-tests-tmp\
   install_ft:
     working_directory: ~/featuretools
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
           command: |
               C:\Users\circleci\Miniconda3\shell\condabin\conda-hook.ps1
               conda activate featuretools
-              pytest featuretools\ -n 2 --ignore=featuretools\dask-tests-tmp\
+              pytest featuretools\ -n 2
   install_ft:
     working_directory: ~/featuretools
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
           command: |
               C:\Users\circleci\Miniconda3\shell\condabin\conda-hook.ps1
               conda activate featuretools
-              pytest featuretools\ -n 2
+              pytest featuretools\
   install_ft:
     working_directory: ~/featuretools
     parameters:

--- a/featuretools/dask-tests-tmp/test_add_lti.py
+++ b/featuretools/dask-tests-tmp/test_add_lti.py
@@ -22,7 +22,6 @@ def run_test():
     pd_order_products = order_products.compute()
     pd_orders = orders.compute()
 
-
     print("Creating entityset...")
     order_products_vtypes = {
         "order_id": ft.variable_types.Id,

--- a/featuretools/dask-tests-tmp/test_add_lti.py
+++ b/featuretools/dask-tests-tmp/test_add_lti.py
@@ -3,7 +3,6 @@ import os
 from datetime import datetime
 
 import dask.dataframe as dd
-import featuretools as ft
 import numpy as np
 import pandas as pd
 from dask.distributed import Client
@@ -11,6 +10,8 @@ from sklearn.ensemble import RandomForestClassifier
 from sklearn.model_selection import cross_val_score, train_test_split
 
 import utils
+
+import featuretools as ft
 
 
 def run_test():

--- a/featuretools/dask-tests-tmp/test_add_lti.py
+++ b/featuretools/dask-tests-tmp/test_add_lti.py
@@ -55,19 +55,18 @@ def run_test():
 
     pd_es = ft.EntitySet("instacart")
     pd_es.entity_from_dataframe(entity_id="order_products",
-                             dataframe=pd_order_products,
-                             index="order_product_id",
-                             time_index="order_time")
+                                dataframe=pd_order_products,
+                                index="order_product_id",
+                                time_index="order_time")
 
     pd_es.entity_from_dataframe(entity_id="orders",
-                             dataframe=pd_orders,
-                             index="order_id",
-                             time_index="order_time")
+                                dataframe=pd_orders,
+                                index="order_id",
+                                time_index="order_time")
 
     print("Adding relationships...")
     es.add_relationship(ft.Relationship(es["orders"]["order_id"], es["order_products"]["order_id"]))
     pd_es.add_relationship(ft.Relationship(pd_es["orders"]["order_id"], pd_es["order_products"]["order_id"]))
-
 
     print("Normalizing entity...")
     es.normalize_entity(base_entity_id="orders", new_entity_id="users", index="user_id")
@@ -78,8 +77,6 @@ def run_test():
     pd_es.add_last_time_indexes()
 
     return es, pd_es
-
-
 
 
 if __name__ == "__main__":
@@ -97,4 +94,3 @@ if __name__ == "__main__":
         print(eid)
         pd.testing.assert_series_equal(d_lti, p_lti, check_names=False)
     print('LTIs are equal')
-

--- a/featuretools/dask-tests-tmp/test_agg.py
+++ b/featuretools/dask-tests-tmp/test_agg.py
@@ -15,10 +15,10 @@ import os
 import sys
 from datetime import datetime
 
-import dask
 import pandas as pd
 from dask import dataframe as dd
 from dask.distributed import Client, wait
+
 from memory_profiler import memory_usage
 
 import featuretools as ft

--- a/featuretools/dask-tests-tmp/utils.py
+++ b/featuretools/dask-tests-tmp/utils.py
@@ -51,7 +51,7 @@ def load_entityset(data_dir):
                              time_index="order_time")
 
     es.add_relationship(ft.Relationship(es["orders"]["order_id"], es["order_products"]["order_id"]))
-    
+
     es.normalize_entity(base_entity_id="orders", new_entity_id="users", index="user_id")
     es.add_last_time_indexes()
 

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -422,7 +422,7 @@ class Entity(object):
 
         if isinstance(self.df, dd.core.DataFrame):
             t = time_type  # skip checking values
-            already_sorted = True # skip sorting
+            already_sorted = True  # skip sorting
         else:
             t = vtypes.NumericTimeIndex
             if col_is_datetime(self.df[variable_id]):

--- a/featuretools/tests/entityset_tests/test_dask.py
+++ b/featuretools/tests/entityset_tests/test_dask.py
@@ -50,14 +50,14 @@ def test_aggregation(es, dask_es):
     # Run DFS using each entity as a target and confirm results match
     for entity in es.entities:
         # remove n_most_common for customers due to ambiguity
-        if entity.id == 'customers':
+        if entity.id in ['customers', 'sessions']:
             agg_primitives.remove('n_most_common')
         fm, _ = ft.dfs(entityset=es,
-                       target_entity=entity.id,
-                       trans_primitives=trans_primitives,
-                       agg_primitives=agg_primitives,
-                       cutoff_time=pd.Timestamp("2019-01-05 04:00"),
-                       max_depth=2)
+                    target_entity=entity.id,
+                    trans_primitives=trans_primitives,
+                    agg_primitives=agg_primitives,
+                    cutoff_time=pd.Timestamp("2019-01-05 04:00"),
+                    max_depth=2)
 
         dask_fm, _ = ft.dfs(entityset=dask_es,
                             target_entity=entity.id,
@@ -65,7 +65,7 @@ def test_aggregation(es, dask_es):
                             agg_primitives=agg_primitives,
                             cutoff_time=pd.Timestamp("2019-01-05 04:00"),
                             max_depth=2)
-        if entity.id == 'customers':
+        if entity.id in ['customers', 'sessions']:
             agg_primitives.append('n_most_common')
         # Use the same columns and make sure both indexes are sorted the same
         dask_computed_fm = dask_fm.compute().set_index(entity.index).loc[fm.index][fm.columns]

--- a/featuretools/tests/entityset_tests/test_dask.py
+++ b/featuretools/tests/entityset_tests/test_dask.py
@@ -191,7 +191,7 @@ def test_add_last_time_indexes():
     es.add_last_time_indexes()
     dask_es.add_last_time_indexes()
 
-    pd.testing.assert_series_equal(es['sessions'].last_time_index.sort_index(), dask_es['sessions'].last_time_index.compute())
+    pd.testing.assert_series_equal(es['sessions'].last_time_index.sort_index(), dask_es['sessions'].last_time_index.compute(), check_names=False)
 
 
 def test_create_entity_with_make_index():
@@ -207,7 +207,7 @@ def test_create_entity_with_make_index():
 
 
 def test_single_table_dask_entityset():
-    primitives_list = ['cum_sum', 'diff', 'absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
+    primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
 
     dask_es = EntitySet(id="dask_es")
     df = pd.DataFrame({"id": [0, 1, 2, 3],
@@ -252,7 +252,7 @@ def test_single_table_dask_entityset():
 
 
 def test_single_table_dask_entityset_ids_not_sorted():
-    primitives_list = ['cum_sum', 'diff', 'absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
+    primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
 
     dask_es = EntitySet(id="dask_es")
     df = pd.DataFrame({"id": [2, 0, 1, 3],
@@ -296,7 +296,7 @@ def test_single_table_dask_entityset_ids_not_sorted():
 
 
 def test_single_table_dask_entityset_with_instance_ids():
-    primitives_list = ['cum_sum', 'diff', 'absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
+    primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
     instance_ids = [0, 1, 3]
 
     dask_es = EntitySet(id="dask_es")
@@ -344,7 +344,7 @@ def test_single_table_dask_entityset_with_instance_ids():
 
 
 def test_single_table_dask_entityset_single_cutoff_time():
-    primitives_list = ['cum_sum', 'diff', 'absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
+    primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
 
     dask_es = EntitySet(id="dask_es")
     df = pd.DataFrame({"id": [0, 1, 2, 3],
@@ -390,7 +390,7 @@ def test_single_table_dask_entityset_single_cutoff_time():
 
 
 def test_single_table_dask_entityset_cutoff_time_df():
-    primitives_list = ['cum_sum', 'diff', 'absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
+    primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
 
     dask_es = EntitySet(id="dask_es")
     df = pd.DataFrame({"id": [0, 1, 2],
@@ -448,7 +448,7 @@ def test_single_table_dask_entityset_dates_not_sorted():
                                  pd.to_datetime('2019-01-01'),
                                  pd.to_datetime('2017-08-25')]})
 
-    primitives_list = ['cum_sum', 'diff', 'absolute', 'is_weekend', 'year', 'day']
+    primitives_list = ['absolute', 'is_weekend', 'year', 'day']
     values_dd = dd.from_pandas(df, npartitions=1)
     vtypes = {
         "id": ft.variable_types.Id,

--- a/featuretools/tests/entityset_tests/test_dask.py
+++ b/featuretools/tests/entityset_tests/test_dask.py
@@ -53,11 +53,11 @@ def test_aggregation(es, dask_es):
         if entity.id in ['customers', 'sessions']:
             agg_primitives.remove('n_most_common')
         fm, _ = ft.dfs(entityset=es,
-                    target_entity=entity.id,
-                    trans_primitives=trans_primitives,
-                    agg_primitives=agg_primitives,
-                    cutoff_time=pd.Timestamp("2019-01-05 04:00"),
-                    max_depth=2)
+                       target_entity=entity.id,
+                       trans_primitives=trans_primitives,
+                       agg_primitives=agg_primitives,
+                       cutoff_time=pd.Timestamp("2019-01-05 04:00"),
+                       max_depth=2)
 
         dask_fm, _ = ft.dfs(entityset=dask_es,
                             target_entity=entity.id,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 description-file = README.md
 [tool:pytest]
-addopts = --doctest-modules --ignore=featuretools/tests/plugin_tests/featuretools_plugin
+addopts = --doctest-modules --ignore=featuretools/tests/plugin_tests/featuretools_plugin  --ignore=featuretools/dask-tests-tmp/
 python_files = featuretools/tests/*
 filterwarnings =
     ignore::DeprecationWarning


### PR DESCRIPTION
Update failing Dask entityset tests
- remove unsupported primitives from tests
- don't check name when comparing Pandas Series

Note that `test_aggregation` sporadically fails due to ambiguity in `NMostCommon`
