### PR TITLE
Refactor update_feature_columns

### DIFF
--- a/featuretools/computational_backends/feature_set_calculator.py
+++ b/featuretools/computational_backends/feature_set_calculator.py
@@ -425,6 +425,7 @@ class FeatureSetCalculator(object):
 
     def _calculate_transform_features(self, features, frame, _df_trie, progress_callback):
         frame_empty = frame.empty if isinstance(frame, pd.DataFrame) else False
+        feature_values = []
         for f in features:
             # handle when no data
             if frame_empty:
@@ -452,10 +453,12 @@ class FeatureSetCalculator(object):
                 values = [strip_values_if_series(value) for value in values]
             else:
                 values = [strip_values_if_series(values)]
-            frame = update_feature_columns(f, frame, values)
+
+            feature_values.append((f, values))
 
             progress_callback(1 / float(self.num_features))
 
+        frame = update_feature_columns(feature_values, frame)
         return frame
 
     def _calculate_groupby_features(self, features, frame, _df_trie, progress_callback):
@@ -582,9 +585,11 @@ class FeatureSetCalculator(object):
         # when no child data, just add all the features to frame with nan
         base_frame_empty = base_frame.empty if isinstance(base_frame, pd.DataFrame) else False
         if base_frame_empty:
+            feature_values = []
             for f in features:
-                update_feature_columns(f, frame, np.full(f.number_output_features, np.nan))
+                feature_values.append((f, np.full(f.number_output_features, np.nan)))
                 progress_callback(1 / float(self.num_features))
+            frame = update_feature_columns(feature_values, frame)
         else:
             relationship_path = test_feature.relationship_path
 
@@ -800,6 +805,7 @@ def _can_agg(feature):
 def agg_wrapper(feats, time_last):
     def wrap(df):
         d = {}
+        feature_values = []
         for f in feats:
             func = f.get_function()
             variable_ids = [bf.get_name() for bf in f.base_features]
@@ -812,7 +818,9 @@ def agg_wrapper(feats, time_last):
 
             if f.number_output_features == 1:
                 values = [values]
-            update_feature_columns(f, d, values)
+            feature_values.append((f, values))
+
+        d = update_feature_columns(feature_values, d)
 
         return pd.Series(d)
     return wrap
@@ -821,10 +829,12 @@ def agg_wrapper(feats, time_last):
 def dask_split_output(row, columns, multi_output_prims):
     d = {}
     for col, val in zip(columns, row):
+        feature_values = []
         if col in multi_output_prims:
-            update_feature_columns(multi_output_prims[col], d, val)
+            feature_values.append((multi_output_prims[col], val))
         else:
-            d[col] = val
+            feature_values.append((col, val))
+        d = update_feature_columns(feature_values, d)
     return pd.Series(d)
 
 
@@ -833,18 +843,21 @@ def set_default_column(frame, f):
         frame[name] = f.default_value
 
 
-def update_feature_columns(feature, data, values):
-    names = feature.get_feature_names()
-    id_col = feature.entityset[feature.entity_id].index
-    assert len(names) == len(values)
-    for name, value in zip(names, values):
-        if isinstance(value, np.ndarray) and isinstance(data, dd.core.DataFrame):
-            new_df = pd.DataFrame({name: value, id_col: data[id_col].compute()})
-            data = data.merge(new_df, on=id_col)
-        else:
-            data[name] = value
+def update_feature_columns(feature_data, data):
+    new_cols = {}
+    for item in feature_data:
+        names = item[0].get_feature_names()
+        values = item[1]
+        assert len(names) == len(values)
+        for name, value in zip(names, values):
+            new_cols[name] = value
 
-    return data
+    # Handle the case where a dict is being updated
+    if isinstance(data, dict):
+        data.update(new_cols)
+        return data
+
+    return data.assign(**new_cols)
 
 
 def strip_values_if_series(values):

--- a/featuretools/dask-tests-tmp/test_agg.py
+++ b/featuretools/dask-tests-tmp/test_agg.py
@@ -18,6 +18,7 @@ from datetime import datetime
 import pandas as pd
 from dask import dataframe as dd
 from dask.distributed import Client, wait
+
 from memory_profiler import memory_usage
 
 import featuretools as ft

--- a/featuretools/dask-tests-tmp/test_agg.py
+++ b/featuretools/dask-tests-tmp/test_agg.py
@@ -18,7 +18,6 @@ from datetime import datetime
 import pandas as pd
 from dask import dataframe as dd
 from dask.distributed import Client, wait
-
 from memory_profiler import memory_usage
 
 import featuretools as ft

--- a/featuretools/primitives/standard/binary_transform.py
+++ b/featuretools/primitives/standard/binary_transform.py
@@ -60,9 +60,6 @@ class GreaterThanScalar(TransformPrimitive):
 
     def get_function(self):
         def greater_than_scalar(vals):
-            # convert series to handle both numeric and datetime case
-            if isinstance(vals, list):
-                vals = pd.Series(vals)
             return vals > self.value
         return greater_than_scalar
 
@@ -116,9 +113,6 @@ class GreaterThanEqualToScalar(TransformPrimitive):
 
     def get_function(self):
         def greater_than_equal_to_scalar(vals):
-            if isinstance(vals, list):
-                vals = pd.Series(vals)
-            # convert series to handle both numeric and datetime case
             return vals >= self.value
         return greater_than_equal_to_scalar
 
@@ -172,9 +166,6 @@ class LessThanScalar(TransformPrimitive):
 
     def get_function(self):
         def less_than_scalar(vals):
-            # convert series to handle both numeric and datetime case
-            if isinstance(vals, list):
-                vals = pd.Series(vals)
             return vals < self.value
         return less_than_scalar
 
@@ -228,9 +219,6 @@ class LessThanEqualToScalar(TransformPrimitive):
 
     def get_function(self):
         def less_than_equal_to_scalar(vals):
-            # convert series to handle both numeric and datetime case
-            if isinstance(vals, list):
-                vals = pd.Series(vals)
             return vals <= self.value
         return less_than_equal_to_scalar
 

--- a/featuretools/primitives/standard/binary_transform.py
+++ b/featuretools/primitives/standard/binary_transform.py
@@ -61,7 +61,9 @@ class GreaterThanScalar(TransformPrimitive):
     def get_function(self):
         def greater_than_scalar(vals):
             # convert series to handle both numeric and datetime case
-            return pd.Series(vals) > self.value
+            if isinstance(vals, list):
+                vals = pd.Series(vals)
+            return vals > self.value
         return greater_than_scalar
 
     def generate_name(self, base_feature_names):
@@ -114,8 +116,10 @@ class GreaterThanEqualToScalar(TransformPrimitive):
 
     def get_function(self):
         def greater_than_equal_to_scalar(vals):
+            if isinstance(vals, list):
+                vals = pd.Series(vals)
             # convert series to handle both numeric and datetime case
-            return pd.Series(vals) >= self.value
+            return vals >= self.value
         return greater_than_equal_to_scalar
 
     def generate_name(self, base_feature_names):
@@ -169,7 +173,9 @@ class LessThanScalar(TransformPrimitive):
     def get_function(self):
         def less_than_scalar(vals):
             # convert series to handle both numeric and datetime case
-            return pd.Series(vals) < self.value
+            if isinstance(vals, list):
+                vals = pd.Series(vals)
+            return vals < self.value
         return less_than_scalar
 
     def generate_name(self, base_feature_names):
@@ -223,7 +229,9 @@ class LessThanEqualToScalar(TransformPrimitive):
     def get_function(self):
         def less_than_equal_to_scalar(vals):
             # convert series to handle both numeric and datetime case
-            return pd.Series(vals) <= self.value
+            if isinstance(vals, list):
+                vals = pd.Series(vals)
+            return vals <= self.value
         return less_than_equal_to_scalar
 
     def generate_name(self, base_feature_names):

--- a/featuretools/primitives/standard/transform_primitive.py
+++ b/featuretools/primitives/standard/transform_primitive.py
@@ -332,7 +332,11 @@ class NumCharacters(TransformPrimitive):
     return_type = Numeric
 
     def get_function(self):
-        return lambda array: pd.Series(array).fillna('').str.len()
+        def character_counter(array):
+            if isinstance(array, list):
+                array = pd.Series(array)
+            return array.fillna('').str.len()
+        return character_counter
 
 
 class NumWords(TransformPrimitive):
@@ -352,7 +356,9 @@ class NumWords(TransformPrimitive):
 
     def get_function(self):
         def word_counter(array):
-            return pd.Series(array).fillna('').str.count(' ') + 1
+            if isinstance(array, list):
+                array = pd.Series(array)
+            return array.fillna('').str.count(' ') + 1
         return word_counter
 
 

--- a/featuretools/primitives/standard/transform_primitive.py
+++ b/featuretools/primitives/standard/transform_primitive.py
@@ -333,8 +333,6 @@ class NumCharacters(TransformPrimitive):
 
     def get_function(self):
         def character_counter(array):
-            if isinstance(array, list):
-                array = pd.Series(array)
             return array.fillna('').str.len()
         return character_counter
 
@@ -356,8 +354,6 @@ class NumWords(TransformPrimitive):
 
     def get_function(self):
         def word_counter(array):
-            if isinstance(array, list):
-                array = pd.Series(array)
             return array.fillna('').str.count(' ') + 1
         return word_counter
 

--- a/featuretools/tests/entityset_tests/test_dask.py
+++ b/featuretools/tests/entityset_tests/test_dask.py
@@ -64,8 +64,7 @@ def test_aggregation(es, dask_es):
                             agg_primitives=agg_primitives,
                             cutoff_time=pd.Timestamp("2019-01-05 04:00"),
                             max_depth=2)
-        if entity.id in ['customers', 'sessions']:
-            agg_primitives.append('n_most_common')
+
         # Use the same columns and make sure both indexes are sorted the same
         dask_computed_fm = dask_fm.compute().set_index(entity.index).loc[fm.index][fm.columns]
         pd.testing.assert_frame_equal(fm, dask_computed_fm, check_dtype=False)

--- a/featuretools/tests/entityset_tests/test_dask.py
+++ b/featuretools/tests/entityset_tests/test_dask.py
@@ -10,7 +10,9 @@ def test_transform(es, dask_es):
     primitives = ft.list_primitives()
     trans_list = primitives[primitives['type'] == 'transform']['name'].tolist()
     # These primitives currently not supported with Dask
-    not_supported = ['cum_mean', 'equal', 'not_equal', 'equal_scalar', 'not_equal_scalar']
+    not_supported = ['cum_count', 'cum_sum', 'cum_max', 'cum_min', 'cum_mean', 'diff', 'percentile', 'equal',
+                     'not_equal', 'equal_scalar', 'not_equal_scalar', 'longitude', 'latitude', 'haversine']
+
     trans_primitives = [prim for prim in trans_list if prim not in not_supported]
     agg_primitives = []
 
@@ -42,16 +44,13 @@ def test_aggregation(es, dask_es):
     primitives = ft.list_primitives()
     trans_primitives = []
     agg_list = primitives[primitives['type'] == 'aggregation']['name'].tolist()
-    not_supported = ['trend', 'first', 'last', 'time_since_first', 'time_since_last']
+    not_supported = ['mode', 'median', 'n_most_common', 'skew', 'entropy', 'first', 'last', 'time_since_first', 'time_since_last', 'trend']
     agg_primitives = [prim for prim in agg_list if prim not in not_supported]
 
     assert es == dask_es
 
     # Run DFS using each entity as a target and confirm results match
     for entity in es.entities:
-        # remove n_most_common for customers due to ambiguity
-        if entity.id in ['customers', 'sessions']:
-            agg_primitives.remove('n_most_common')
         fm, _ = ft.dfs(entityset=es,
                        target_entity=entity.id,
                        trans_primitives=trans_primitives,


### PR DESCRIPTION
Refactored `update_feature_columns()` in `feature_set_calculator.py` to use `df.assign()` for adding new columns to the feature matrix to improve performance for Dask.

Also removed the `.compute()` call that was used to merge values that were passed as an `np.ndarray`. Removing this required updates to a few primitives to make sure the values are returned as a `dask.Series` when working with a Dask entityset.

Finally, updated tests in `test_dask.py` to skip unsupported primitives as documented in #904 as some were failing after the updates above.

Fixes #900 
Fixes #923 