### PR TITLE
Dask DFS errors with unsupported primitives

### DIFF
--- a/featuretools/computational_backends/feature_set_calculator.py
+++ b/featuretools/computational_backends/feature_set_calculator.py
@@ -246,7 +246,8 @@ class FeatureSetCalculator(object):
         # Pass filtered values, even if we are using a full df.
         if need_full_entity:
             if isinstance(filter_values, dd.core.Series):
-                raise ValueError("Cannot use primitives that require full entity with Dask")
+                msg = "Cannot use primitives that require full entity with Dask EntitySets"
+                raise ValueError(msg)
             filtered_df = df[df[filter_variable].isin(filter_values)]
         else:
             filtered_df = df

--- a/featuretools/computational_backends/feature_set_calculator.py
+++ b/featuretools/computational_backends/feature_set_calculator.py
@@ -246,7 +246,7 @@ class FeatureSetCalculator(object):
         # Pass filtered values, even if we are using a full df.
         if need_full_entity:
             if isinstance(filter_values, dd.core.Series):
-                filter_values = filter_values.compute()
+                raise ValueError("Cannot use primitives that require full entity with Dask")
             filtered_df = df[df[filter_variable].isin(filter_values)]
         else:
             filtered_df = df

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -31,6 +31,8 @@ class PrimitiveBase(object):
     base_of_exclude = None
     # (bool) If True will only make one feature per unique set of base features
     commutative = False
+    # (bool) If True, is compatible with Dask EntitySets
+    dask_compatible = False
 
     def __init__(self):
         pass

--- a/featuretools/primitives/standard/aggregation_primitives.py
+++ b/featuretools/primitives/standard/aggregation_primitives.py
@@ -33,6 +33,7 @@ class Count(AggregationPrimitive):
     return_type = Numeric
     stack_on_self = False
     default_value = 0
+    dask_compatible = True
 
     def get_function(self):
         return pd.Series.count
@@ -60,6 +61,7 @@ class Sum(AggregationPrimitive):
     stack_on_self = False
     stack_on_exclude = [Count]
     default_value = 0
+    dask_compatible = True
 
     def get_function(self):
         return np.sum
@@ -89,6 +91,7 @@ class Mean(AggregationPrimitive):
     name = "mean"
     input_types = [Numeric]
     return_type = Numeric
+    dask_compatible = True
 
     def __init__(self, skipna=True):
         self.skipna = skipna
@@ -155,6 +158,7 @@ class Min(AggregationPrimitive):
     input_types = [Numeric]
     return_type = Numeric
     stack_on_self = False
+    dask_compatible = True
 
     def get_function(self):
         return np.min
@@ -175,6 +179,7 @@ class Max(AggregationPrimitive):
     input_types = [Numeric]
     return_type = Numeric
     stack_on_self = False
+    dask_compatible = True
 
     def get_function(self):
         return np.max
@@ -243,6 +248,7 @@ class NumTrue(AggregationPrimitive):
     default_value = 0
     stack_on = []
     stack_on_exclude = []
+    dask_compatible = True
 
     def get_function(self):
         return np.sum
@@ -280,6 +286,7 @@ class PercentTrue(AggregationPrimitive):
     stack_on = []
     stack_on_exclude = []
     default_value = 0
+    dask_compatible = True
 
     def get_function(self):
         def percent_true(s):
@@ -551,6 +558,7 @@ class Std(AggregationPrimitive):
     input_types = [Numeric]
     return_type = Numeric
     stack_on_self = False
+    dask_compatible = True
 
     def get_function(self):
         return np.std
@@ -621,6 +629,7 @@ class Any(AggregationPrimitive):
     input_types = [Boolean]
     return_type = Boolean
     stack_on_self = False
+    dask_compatible = True
 
     def get_function(self):
         return np.any
@@ -651,6 +660,7 @@ class All(AggregationPrimitive):
     input_types = [Boolean]
     return_type = Boolean
     stack_on_self = False
+    dask_compatible = True
 
     def get_function(self):
         return np.all

--- a/featuretools/primitives/standard/binary_transform.py
+++ b/featuretools/primitives/standard/binary_transform.py
@@ -30,6 +30,7 @@ class GreaterThan(TransformPrimitive):
     name = "greater_than"
     input_types = [[Numeric, Numeric], [Datetime, Datetime], [Ordinal, Ordinal]]
     return_type = Boolean
+    dask_compatible = True
 
     def get_function(self):
         return np.greater
@@ -54,6 +55,7 @@ class GreaterThanScalar(TransformPrimitive):
     name = "greater_than_scalar"
     input_types = [[Numeric], [Datetime], [Ordinal]]
     return_type = Boolean
+    dask_compatible = True
 
     def __init__(self, value=0):
         self.value = value
@@ -83,6 +85,7 @@ class GreaterThanEqualTo(TransformPrimitive):
     name = "greater_than_equal_to"
     input_types = [[Numeric, Numeric], [Datetime, Datetime], [Ordinal, Ordinal]]
     return_type = Boolean
+    dask_compatible = True
 
     def get_function(self):
         return np.greater_equal
@@ -107,6 +110,7 @@ class GreaterThanEqualToScalar(TransformPrimitive):
     name = "greater_than_equal_to_scalar"
     input_types = [[Numeric], [Datetime], [Ordinal]]
     return_type = Boolean
+    dask_compatible = True
 
     def __init__(self, value=0):
         self.value = value
@@ -136,6 +140,7 @@ class LessThan(TransformPrimitive):
     name = "less_than"
     input_types = [[Numeric, Numeric], [Datetime, Datetime], [Ordinal, Ordinal]]
     return_type = Boolean
+    dask_compatible = True
 
     def get_function(self):
         return np.less
@@ -160,6 +165,7 @@ class LessThanScalar(TransformPrimitive):
     name = "less_than_scalar"
     input_types = [[Numeric], [Datetime], [Ordinal]]
     return_type = Boolean
+    dask_compatible = True
 
     def __init__(self, value=0):
         self.value = value
@@ -189,6 +195,7 @@ class LessThanEqualTo(TransformPrimitive):
     name = "less_than_equal_to"
     input_types = [[Numeric, Numeric], [Datetime, Datetime], [Ordinal, Ordinal]]
     return_type = Boolean
+    dask_compatible = True
 
     def get_function(self):
         return np.less_equal
@@ -213,6 +220,7 @@ class LessThanEqualToScalar(TransformPrimitive):
     name = "less_than_equal_to_scalar"
     input_types = [[Numeric], [Datetime], [Ordinal]]
     return_type = Boolean
+    dask_compatible = True
 
     def __init__(self, value=0):
         self.value = value
@@ -351,6 +359,7 @@ class AddNumeric(TransformPrimitive):
     input_types = [Numeric, Numeric]
     return_type = Numeric
     commutative = True
+    dask_compatible = True
 
     def get_function(self):
         return np.add
@@ -374,6 +383,7 @@ class AddNumericScalar(TransformPrimitive):
     name = "add_numeric_scalar"
     input_types = [Numeric]
     return_type = Numeric
+    dask_compatible = True
 
     def __init__(self, value=0):
         self.value = value
@@ -408,6 +418,7 @@ class SubtractNumeric(TransformPrimitive):
     name = "subtract_numeric"
     input_types = [Numeric, Numeric]
     return_type = Numeric
+    dask_compatible = True
 
     def __init__(self, commutative=True):
         self.commutative = commutative
@@ -434,6 +445,7 @@ class SubtractNumericScalar(TransformPrimitive):
     name = "subtract_numeric_scalar"
     input_types = [Numeric]
     return_type = Numeric
+    dask_compatible = True
 
     def __init__(self, value=0):
         self.value = value
@@ -463,6 +475,7 @@ class ScalarSubtractNumericFeature(TransformPrimitive):
     name = "scalar_subtract_numeric_feature"
     input_types = [Numeric]
     return_type = Numeric
+    dask_compatible = True
 
     def __init__(self, value=0):
         self.value = value
@@ -497,6 +510,7 @@ class MultiplyNumeric(TransformPrimitive):
     ]
     return_type = Numeric
     commutative = True
+    dask_compatible = True
 
     def get_function(self):
         return np.multiply
@@ -520,6 +534,7 @@ class MultiplyNumericScalar(TransformPrimitive):
     name = "multiply_numeric_scalar"
     input_types = [Numeric]
     return_type = Numeric
+    dask_compatible = True
 
     def __init__(self, value=1):
         self.value = value
@@ -551,6 +566,7 @@ class MultiplyBoolean(TransformPrimitive):
 
     return_type = Boolean
     commutative = True
+    dask_compatible = True
 
     def get_function(self):
         return np.bitwise_and
@@ -580,6 +596,7 @@ class DivideNumeric(TransformPrimitive):
     name = "divide_numeric"
     input_types = [Numeric, Numeric]
     return_type = Numeric
+    dask_compatible = True
 
     def __init__(self, commutative=False):
         self.commutative = commutative
@@ -606,6 +623,7 @@ class DivideNumericScalar(TransformPrimitive):
     name = "divide_numeric_scalar"
     input_types = [Numeric]
     return_type = Numeric
+    dask_compatible = True
 
     def __init__(self, value=1):
         self.value = value
@@ -635,6 +653,7 @@ class DivideByFeature(TransformPrimitive):
     name = "divide_by_feature"
     input_types = [Numeric]
     return_type = Numeric
+    dask_compatible = True
 
     def __init__(self, value=1):
         self.value = value
@@ -664,6 +683,7 @@ class ModuloNumeric(TransformPrimitive):
     name = "modulo_numeric"
     input_types = [Numeric, Numeric]
     return_type = Numeric
+    dask_compatible = True
 
     def get_function(self):
         return np.mod
@@ -688,6 +708,7 @@ class ModuloNumericScalar(TransformPrimitive):
     name = "modulo_numeric_scalar"
     input_types = [Numeric]
     return_type = Numeric
+    dask_compatible = True
 
     def __init__(self, value=1):
         self.value = value
@@ -717,6 +738,7 @@ class ModuloByFeature(TransformPrimitive):
     name = "modulo_by_feature"
     input_types = [Numeric]
     return_type = Numeric
+    dask_compatible = True
 
     def __init__(self, value=1):
         self.value = value
@@ -747,6 +769,7 @@ class And(TransformPrimitive):
     input_types = [Boolean, Boolean]
     return_type = Boolean
     commutative = True
+    dask_compatible = True
 
     def get_function(self):
         return np.logical_and
@@ -772,6 +795,7 @@ class Or(TransformPrimitive):
     input_types = [Boolean, Boolean]
     return_type = Boolean
     commutative = True
+    dask_compatible = True
 
     def get_function(self):
         return np.logical_or

--- a/featuretools/primitives/standard/transform_primitive.py
+++ b/featuretools/primitives/standard/transform_primitive.py
@@ -535,7 +535,6 @@ class Percentile(TransformPrimitive):
     uses_full_entity = True
     input_types = [Numeric]
     return_type = Numeric
-    dask_compatible = True
 
     def get_function(self):
         return lambda array: pd.Series(array).rank(pct=True)

--- a/featuretools/primitives/standard/transform_primitive.py
+++ b/featuretools/primitives/standard/transform_primitive.py
@@ -29,6 +29,7 @@ class IsNull(TransformPrimitive):
     name = "is_null"
     input_types = [Variable]
     return_type = Boolean
+    dask_compatible = True
 
     def get_function(self):
         def isnull(array):
@@ -50,6 +51,7 @@ class Absolute(TransformPrimitive):
     name = "absolute"
     input_types = [Numeric]
     return_type = Numeric
+    dask_compatible = True
 
     def get_function(self):
         return np.absolute
@@ -107,6 +109,7 @@ class Day(TransformPrimitive):
     name = "day"
     input_types = [Datetime]
     return_type = Ordinal
+    dask_compatible = True
 
     def get_function(self):
         def day(vals):
@@ -131,6 +134,7 @@ class Hour(TransformPrimitive):
     name = "hour"
     input_types = [Datetime]
     return_type = Ordinal
+    dask_compatible = True
 
     def get_function(self):
         def hour(vals):
@@ -155,6 +159,7 @@ class Second(TransformPrimitive):
     name = "second"
     input_types = [Datetime]
     return_type = Numeric
+    dask_compatible = True
 
     def get_function(self):
         def second(vals):
@@ -179,6 +184,7 @@ class Minute(TransformPrimitive):
     name = "minute"
     input_types = [Datetime]
     return_type = Numeric
+    dask_compatible = True
 
     def get_function(self):
         def minute(vals):
@@ -208,6 +214,7 @@ class Week(TransformPrimitive):
     name = "week"
     input_types = [Datetime]
     return_type = Ordinal
+    dask_compatible = True
 
     def get_function(self):
         def week(vals):
@@ -232,6 +239,7 @@ class Month(TransformPrimitive):
     name = "month"
     input_types = [Datetime]
     return_type = Ordinal
+    dask_compatible = True
 
     def get_function(self):
         def month(vals):
@@ -256,6 +264,7 @@ class Year(TransformPrimitive):
     name = "year"
     input_types = [Datetime]
     return_type = Ordinal
+    dask_compatible = True
 
     def get_function(self):
         def year(vals):
@@ -280,6 +289,7 @@ class IsWeekend(TransformPrimitive):
     name = "is_weekend"
     input_types = [Datetime]
     return_type = Boolean
+    dask_compatible = True
 
     def get_function(self):
         def is_weekend(vals):
@@ -308,6 +318,7 @@ class Weekday(TransformPrimitive):
     name = "weekday"
     input_types = [Datetime]
     return_type = Ordinal
+    dask_compatible = True
 
     def get_function(self):
         def weekday(vals):
@@ -330,6 +341,7 @@ class NumCharacters(TransformPrimitive):
     name = 'num_characters'
     input_types = [Text]
     return_type = Numeric
+    dask_compatible = True
 
     def get_function(self):
         def character_counter(array):
@@ -351,6 +363,7 @@ class NumWords(TransformPrimitive):
     name = 'num_words'
     input_types = [Text]
     return_type = Numeric
+    dask_compatible = True
 
     def get_function(self):
         def word_counter(array):
@@ -393,6 +406,7 @@ class TimeSince(TransformPrimitive):
     input_types = [[DatetimeTimeIndex], [Datetime]]
     return_type = Numeric
     uses_calc_time = True
+    dask_compatible = True
 
     def __init__(self, unit="seconds"):
         self.unit = unit.lower()
@@ -417,6 +431,7 @@ class IsIn(TransformPrimitive):
     name = "isin"
     input_types = [Variable]
     return_type = Boolean
+    dask_compatible = True
 
     def __init__(self, list_of_outputs=None):
         self.list_of_outputs = list_of_outputs
@@ -472,6 +487,7 @@ class Negate(TransformPrimitive):
     name = "negate"
     input_types = [Numeric]
     return_type = Numeric
+    dask_compatible = True
 
     def get_function(self):
         def negate(vals):
@@ -493,6 +509,7 @@ class Not(TransformPrimitive):
     name = "not"
     input_types = [Boolean]
     return_type = Boolean
+    dask_compatible = True
 
     def generate_name(self, base_feature_names):
         return u"NOT({})".format(base_feature_names[0])
@@ -518,6 +535,7 @@ class Percentile(TransformPrimitive):
     uses_full_entity = True
     input_types = [Numeric]
     return_type = Numeric
+    dask_compatible = True
 
     def get_function(self):
         return lambda array: pd.Series(array).rank(pct=True)

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -182,6 +182,8 @@ class DeepFeatureSynthesis(object):
             agg_primitives = [primitives.Sum, primitives.Std, primitives.Max, primitives.Skew,
                               primitives.Min, primitives.Mean, primitives.Count,
                               primitives.PercentTrue, primitives.NumUnique, primitives.Mode]
+            if any(isinstance(e.df, dd.DataFrame) for e in self.es.entities):
+                agg_primitives = [p for p in agg_primitives if p.dask_compatible]
         self.agg_primitives = []
         agg_prim_dict = primitives.get_aggregation_primitives()
         for a in agg_primitives:
@@ -201,6 +203,8 @@ class DeepFeatureSynthesis(object):
             trans_primitives = [primitives.Day, primitives.Year, primitives.Month,
                                 primitives.Weekday, primitives.Haversine,
                                 primitives.NumWords, primitives.NumCharacters]  # primitives.TimeSince
+            if any(isinstance(e.df, dd.DataFrame) for e in self.es.entities):
+                trans_primitives = [p for p in trans_primitives if p.dask_compatible]
         self.trans_primitives = []
         for t in trans_primitives:
             t = check_trans_primitive(t)
@@ -231,7 +235,7 @@ class DeepFeatureSynthesis(object):
             primitive_options = {}
         all_primitives = self.trans_primitives + self.agg_primitives + \
             self.where_primitives + self.groupby_trans_primitives
-        if any([isinstance(entity.df, dd.DataFrame) for entity in self.es.entities]):
+        if any(isinstance(entity.df, dd.DataFrame) for entity in self.es.entities):
             if not all([primitive.dask_compatible for primitive in all_primitives]):
                 bad_primitives = ", ".join([prim.name for prim in all_primitives if not prim.dask_compatible])
                 raise ValueError('Selected primitives are incompatible with Dask EntitySets: {}'.format(bad_primitives))

--- a/featuretools/tests/computational_backend/test_feature_set_calculator.py
+++ b/featuretools/tests/computational_backend/test_feature_set_calculator.py
@@ -90,6 +90,21 @@ def test_full_entity_trans_of_agg(es):
     assert v == 82
 
 
+def test_full_entity_error_dask(dask_es):
+    agg_feat = ft.Feature(dask_es['log']['value'], parent_entity=dask_es['customers'],
+                          primitive=Sum)
+    trans_feat = ft.Feature(agg_feat, primitive=CumSum)
+
+    feature_set = FeatureSet([trans_feat])
+    calculator = FeatureSetCalculator(dask_es,
+                                      time_last=None,
+                                      feature_set=feature_set)
+    error_text = "Cannot use primitives that require full entity with Dask"
+
+    with pytest.raises(ValueError, match=error_text):
+        df = calculator.run(np.array([1]))
+
+
 def test_make_agg_feat_of_identity_index_variable(es):
     agg_feat = ft.Feature(es['log']['id'], parent_entity=es['sessions'], primitive=Count)
 

--- a/featuretools/tests/computational_backend/test_feature_set_calculator.py
+++ b/featuretools/tests/computational_backend/test_feature_set_calculator.py
@@ -102,7 +102,7 @@ def test_full_entity_error_dask(dask_es):
     error_text = "Cannot use primitives that require full entity with Dask"
 
     with pytest.raises(ValueError, match=error_text):
-        df = calculator.run(np.array([1]))
+        calculator.run(np.array([1]))
 
 
 def test_make_agg_feat_of_identity_index_variable(es):

--- a/featuretools/tests/entityset_tests/test_dask_hackathon.py
+++ b/featuretools/tests/entityset_tests/test_dask_hackathon.py
@@ -17,7 +17,7 @@ def test_hackathon_single_table():
         index="RESPID",
     )
 
-    trans_primitives = ['cum_sum', 'diff', 'absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
+    trans_primitives = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
 
     fm, _ = ft.dfs(entityset=es,
                    target_entity="users",

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -111,10 +111,10 @@ def test_errors_unsupported_primitives_dask(dask_es):
     bad_trans_prim.dask_compatible, bad_agg_prim.dask_compatible = False, False
     error_text = "Selected primitives are incompatible with Dask EntitySets: cum_sum, num_unique"
     with pytest.raises(ValueError, match=error_text):
-        dfs_obj = DeepFeatureSynthesis(target_entity_id='sessions',
-                                       entityset=dask_es,
-                                       agg_primitives=[bad_agg_prim],
-                                       trans_primitives=[bad_trans_prim])
+        DeepFeatureSynthesis(target_entity_id='sessions',
+                             entityset=dask_es,
+                             agg_primitives=[bad_agg_prim],
+                             trans_primitives=[bad_trans_prim])
 
 
 def test_error_for_missing_target_entity(es):

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -105,6 +105,18 @@ def test_only_makes_supplied_agg_feat(es):
     assert len(other_agg_features) == 0
 
 
+def test_errors_unsupported_primitives_dask(dask_es):
+    bad_trans_prim = CumSum()
+    bad_agg_prim = NumUnique()
+    bad_trans_prim.dask_compatible, bad_agg_prim.dask_compatible = False, False
+    error_text = "Selected primitives are incompatible with Dask EntitySets: cum_sum, num_unique"
+    with pytest.raises(ValueError, match=error_text):
+        dfs_obj = DeepFeatureSynthesis(target_entity_id='sessions',
+                                       entityset=dask_es,
+                                       agg_primitives=[bad_agg_prim],
+                                       trans_primitives=[bad_trans_prim])
+
+
 def test_error_for_missing_target_entity(es):
     error_text = 'Provided target entity missing_entity does not exist in ecommerce'
     with pytest.raises(KeyError, match=error_text):


### PR DESCRIPTION
- Adds `dask_compatible` flag to all primitives
- If using Dask dataframes, checks all primitives are Dask compatible before running DFS and errors if they are not
- Removes compute call that would only have been hit with primitives that use full entity (unsupported with Dask)

Resolves #919 and #898 