### PR TITLE
Add dtype to interesting_values

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,7 @@ Changelog
         * ft.encode_features - use less memory for one-hot encoded columns (:pr:`876`)
     * Fixes
         * Use logger.warning to fix deprecated logger.warn (:pr:`871`)
+        * Add dtype to interesting_values to fix deprecated empty Series with no dtype (:pr:`933`)
     * Changes
         * Change premium primitives CI test to Python 3.6 (:pr:`916`)
         * Remove Python 3.5 support (:pr:`917`)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -19,7 +19,7 @@ Changelog
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`rwedge`
+    :user:`frances-h`, :user:`gsheni`, :user:`rwedge`
 
 **v0.13.4 Mar 27, 2020**
     .. warning::

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -346,7 +346,7 @@ class Entity(object):
         for variable in self.variables:
             # some heuristics to find basic 'where'-able variables
             if isinstance(variable, vtypes.Discrete):
-                variable.interesting_values = pd.Series()
+                variable.interesting_values = pd.Series(dtype=variable.entity.df[variable.id].dtype)
 
                 # TODO - consider removing this constraints
                 # don't add interesting values for entities in relationships

--- a/featuretools/tests/entityset_tests/test_entity.py
+++ b/featuretools/tests/entityset_tests/test_entity.py
@@ -17,6 +17,14 @@ def test_enforces_variable_id_is_str(es):
         variable_types.Categorical(1, es["customers"])
 
 
+def test_no_column_default_datetime(es):
+    variable = variable_types.Datetime("new_time", es["customers"])
+    assert variable.interesting_values.dtype == "datetime64[ns]"
+
+    variable = variable_types.Timedelta("timedelta", es["customers"])
+    assert variable.interesting_values.dtype == "timedelta64[ns]"
+
+
 def test_is_index_column(es):
     assert es['cohorts'].index == 'cohort'
 

--- a/featuretools/variable_types/variable.py
+++ b/featuretools/variable_types/variable.py
@@ -28,7 +28,13 @@ class Variable(object):
         self.entity_id = entity.id
         assert entity.entityset is not None, "Entity must contain reference to EntitySet"
         self.entity = entity
-        self._interesting_values = pd.Series()
+        if self.id not in self.entity.df:
+            default_dtype = self._default_pandas_dtype
+            if isinstance(default_dtype, np.datetime64):
+                default_dtype = 'datetime64[ns]'
+        else:
+            default_dtype = self.entity.df[self.id].dtype
+        self._interesting_values = pd.Series(dtype=default_dtype)
 
     @property
     def entityset(self):
@@ -112,7 +118,6 @@ class Discrete(Variable):
 
     def __init__(self, id, entity, name=None):
         super(Discrete, self).__init__(id, entity, name)
-        self._interesting_values = pd.Series()
 
     @property
     def interesting_values(self):

--- a/featuretools/variable_types/variable.py
+++ b/featuretools/variable_types/variable.py
@@ -30,8 +30,10 @@ class Variable(object):
         self.entity = entity
         if self.id not in self.entity.df:
             default_dtype = self._default_pandas_dtype
-            if isinstance(default_dtype, np.datetime64):
+            if default_dtype == np.datetime64:
                 default_dtype = 'datetime64[ns]'
+            if default_dtype == np.timedelta64:
+                default_dtype = 'timedelta64[ns]'
         else:
             default_dtype = self.entity.df[self.id].dtype
         self._interesting_values = pd.Series(dtype=default_dtype)

--- a/featuretools/variable_types/variable.py
+++ b/featuretools/variable_types/variable.py
@@ -88,7 +88,8 @@ class Variable(object):
 
     @interesting_values.setter
     def interesting_values(self, interesting_values):
-        self._interesting_values = pd.Series(interesting_values)
+        self._interesting_values = pd.Series(interesting_values,
+                                             dtype=self._interesting_values.dtype)
 
     @property
     def series(self):
@@ -128,7 +129,8 @@ class Discrete(Variable):
         seen = set()
         seen_add = seen.add
         self._interesting_values = pd.Series([v for v in values if not
-                                              (v in seen or seen_add(v))])
+                                              (v in seen or seen_add(v))],
+                                             dtype=self._interesting_values.dtype)
 
 
 class Boolean(Variable):


### PR DESCRIPTION
- Add dtype to `interesting_values` to silence Pandas DeprecationWarning

Fixes #928