### PR TITLE
Update get_names output

### DIFF
--- a/featuretools/primitives/base/aggregation_primitive_base.py
+++ b/featuretools/primitives/base/aggregation_primitive_base.py
@@ -33,6 +33,8 @@ class AggregationPrimitive(PrimitiveBase):
                                        parent_entity_id,
                                        where_str,
                                        use_prev_str)
+        if n == 1:
+            return [base_name]
         return [base_name + "[%s]" % i for i in range(n)]
 
 

--- a/featuretools/primitives/base/transform_primitive_base.py
+++ b/featuretools/primitives/base/transform_primitive_base.py
@@ -23,6 +23,8 @@ class TransformPrimitive(PrimitiveBase):
     def generate_names(self, base_feature_names):
         n = self.number_output_features
         base_name = self.generate_name(base_feature_names)
+        if n == 1:
+            return [base_name]
         return [base_name + "[%s]" % i for i in range(n)]
 
 

--- a/featuretools/tests/primitive_tests/test_agg_feats.py
+++ b/featuretools/tests/primitive_tests/test_agg_feats.py
@@ -679,3 +679,19 @@ def test_override_multi_feature_names(es):
 
     for name in expected_names:
         assert name in fm.columns
+
+
+def test_get_name_and_get_names_for_single_feature(es):
+    _, feature_defs = ft.dfs(entityset=es,
+                             target_entity="customers",
+                             agg_primitives=["max"],
+                             trans_primitives=[],
+                             max_depth=2)
+
+    agg_features = [feature for feature in feature_defs
+                    if isinstance(feature, ft.feature_base.feature_base.AggregationFeature)]
+    for feature in agg_features:
+        name = feature.get_name()
+        names = feature.get_names()
+        assert len(names) == 1
+        assert names[0] == name

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -905,3 +905,18 @@ def test_override_multi_feature_names(es):
 
     for name in expected_names:
         assert name in fm.columns
+
+
+def test_get_name_and_get_names_for_single_feature(es):
+    _, feature_defs = ft.dfs(entityset=es,
+                             target_entity="customers",
+                             agg_primitives=[],
+                             trans_primitives=["month"],
+                             max_depth=1)
+    transform_features = [feature for feature in feature_defs
+                          if isinstance(feature, ft.feature_base.feature_base.TransformFeature)]
+    for feature in transform_features:
+        name = feature.get_name()
+        names = feature.get_names()
+        assert len(names) == 1
+        assert names[0] == name


### PR DESCRIPTION
### Update Feature.get_names() Output

Update output of `Feature.get_names()` so that if the feature creates only a single output feature, the single name in the list returned by `Feature.get_names()` matches the name returned by `Feature.get_name()`

Fixes #874 