### PR TITLE
Restore len() call for Pandas in EntitySets.add_relationships

### DIFF
--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -3,8 +3,9 @@ import logging
 from collections import defaultdict
 
 import dask.dataframe as dd
+import numpy as np
 import pandas as pd
-from pandas.api.types import is_dtype_equal
+from pandas.api.types import is_dtype_equal, is_numeric_dtype
 
 import featuretools.variable_types.variable as vtypes
 from featuretools.entityset import deserialize, serialize
@@ -254,9 +255,10 @@ class EntitySet(object):
         # default to object dtypes for discrete variables, but
         # indexes/ids default to ints. In this case, we convert
         # the empty column's type to int
-        # if (len(child_e.df) == 0 and child_e.df[child_v].dtype == object and
-        #         is_numeric_dtype(parent_e.df[parent_v])):
-        #     child_e.df[child_v] = pd.Series(name=child_v, dtype=np.int64)
+        if isinstance(child_e.df, pd.DataFrame) and \
+                (len(child_e.df) == 0 and child_e.df[child_v].dtype == object and
+                 is_numeric_dtype(parent_e.df[parent_v])):
+            child_e.df[child_v] = pd.Series(name=child_v, dtype=np.int64)
 
         parent_dtype = parent_e.df[parent_v].dtype
         child_dtype = child_e.df[child_v].dtype

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -123,6 +123,7 @@ def test_add_relationship_empty_child_convert_dtype(es):
     relationship = ft.Relationship(es["sessions"]["id"], es["log"]["session_id"])
     es['log'].df = pd.DataFrame(columns=es['log'].df.columns)
     assert len(es['log'].df) == 0
+    assert es['log'].df['session_id'].dtype == 'object'
 
     es.relationships.remove(relationship)
     assert(relationship not in es.relationships)

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -119,6 +119,18 @@ def test_add_relationship_errors_on_dtype_mismatch(es):
         es.add_relationship(mismatch)
 
 
+def test_add_relationship_empty_child_convert_dtype(es):
+    relationship = ft.Relationship(es["sessions"]["id"], es["log"]["session_id"])
+    es['log'].df = pd.DataFrame(columns=es['log'].df.columns)
+    assert len(es['log'].df) == 0
+
+    es.relationships.remove(relationship)
+    assert(relationship not in es.relationships)
+
+    es.add_relationship(relationship)
+    assert es['log'].df['session_id'].dtype == 'int64'
+
+
 def test_query_by_id(es):
     df = es['log'].query_by_values(instance_vals=[0])
     assert df['id'].values[0] == 0


### PR DESCRIPTION
Resolves #903 

The `len` call in question covers an edge case relating to adding a relationship with an empty child dataframe. The default dtype of an empty Pandas DataFrame is `object`, so adding a relationship where they dtype of the linking variable is not `object` fails.

We are not supporting empty entity dataframes with Dask, so this check can be safely skipped.