### PR TITLE
Add include_cutoff_time arg to control whether data at cutoff times a…

### DIFF
--- a/docs/source/automated_feature_engineering/handling_time.rst
+++ b/docs/source/automated_feature_engineering/handling_time.rst
@@ -132,7 +132,7 @@ For example, a customer's session has multiple transactions which can happen at 
 Featuretools can automatically add last time indexes to every :class:`Entity` in an :class:`Entityset` by running ``EntitySet.add_last_time_indexes()``. If a ``last_time_index`` has been set, Featuretools will check to see if the ``last_time_index`` is after the start of the training window. That, combined with the cutoff time, allows DFS to discover which data is relevant for a given training window.
 
 
-Include data at cutoff times
+Excluding data at cutoff times
 -----------------------------------------------
 
 There are some situations where data is right just on the cutoff time. For example, let say you have to predict one month revenue for each store using sales data. One of the them is the revenue from ``2020-01-01`` to ``2020-01-31`` and there are bunch of sale history data before that time, including the one occured at ``2020-01-01 00:00:00``. You might want to include(or exclude) the data in feature calculation for this cutoff time. This can be controlled by using the ``include_cutoff_time`` parameter to :func:`featuretools.dfs` or :func:`featuretools.calculate_feature_matrix`::

--- a/docs/source/automated_feature_engineering/handling_time.rst
+++ b/docs/source/automated_feature_engineering/handling_time.rst
@@ -131,6 +131,25 @@ For example, a customer's session has multiple transactions which can happen at 
 
 Featuretools can automatically add last time indexes to every :class:`Entity` in an :class:`Entityset` by running ``EntitySet.add_last_time_indexes()``. If a ``last_time_index`` has been set, Featuretools will check to see if the ``last_time_index`` is after the start of the training window. That, combined with the cutoff time, allows DFS to discover which data is relevant for a given training window.
 
+
+Include data at cutoff times
+-----------------------------------------------
+
+There are some situations where data is right just on the cutoff time. For example, let say you have to predict one month revenue for each store using sales data. One of the them is the revenue from ``2020-01-01`` to ``2020-01-31`` and there are bunch of sale history data before that time, including the one occured at ``2020-01-01 00:00:00``. You might want to include(or exclude) the data in feature calculation for this cutoff time. This can be controlled by using the ``include_cutoff_time`` parameter to :func:`featuretools.dfs` or :func:`featuretools.calculate_feature_matrix`::
+
+    fm = ft.calculate_feature_matrix(features=features,
+                                     entityset=es_transactions,
+                                     cutoff_time=ct_transactions,
+                                     include_cutoff_time=True)
+
+    fm, features = ft.dfs(entityset=es,
+                          target_entity='customers',
+                          cutoff_time=pd.Timestamp("2014-1-1 04:00"),
+                          instance_ids=[1,2,3],
+                          cutoff_time_in_index=True,
+                          include_cutoff_time=False)
+
+
 .. _approximate:
 
 Approximating Features by Rounding Cutoff Times

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -38,7 +38,7 @@ Changelog
 * Using training windows in feature calculations can result in different values than previous versions.
   This was done to prevent consecutive training windows from overlapping by excluding data at the oldest point in time.
   For example, if we use a cutoff time at the first minute of the hour with a one hour training window,
-  the first minute of the previous hour will no longer be included in the feature calculation. You can control it by setting `include_cutoff_time`.
+  the first minute of the previous hour will no longer be included in the feature calculation.
 
 **v0.13.4 Mar 27, 2020**
     .. warning::

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,12 +5,13 @@ Changelog
 **Future Release**
     * Enhancements
         * Add `get_default_aggregation_primitives` and `get_default_transform_primitives` (:pr:`945`)
+        * Add `include_cutoff_time` arg - control whether data at cutoff times are included in feature calculations (:pr:`959`)
     * Fixes
     * Changes
     * Documentation Changes
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`
+    :user:`gsheni`, :user:`rightx2`, :user:`jeff-hernandez`
 
 **v0.14.0 Apr 30, 2020**
     * Enhancements
@@ -37,7 +38,7 @@ Changelog
 * Using training windows in feature calculations can result in different values than previous versions.
   This was done to prevent consecutive training windows from overlapping by excluding data at the oldest point in time.
   For example, if we use a cutoff time at the first minute of the hour with a one hour training window,
-  the first minute of the previous hour will no longer be included in the feature calculation.
+  the first minute of the previous hour will no longer be included in the feature calculation. You can control it by setting `include_cutoff_time`.
 
 **v0.13.4 Mar 27, 2020**
     .. warning::

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,7 +6,7 @@ Changelog
     * Enhancements
         * Add ``get_default_aggregation_primitives`` and ``get_default_transform_primitives`` (:pr:`945`)
         * Allow cutoff time dataframe columns to be in any order (:pr:`969`)
-        * Add `include_cutoff_time` arg - control whether data at cutoff times are included in feature calculations (:pr:`959`)
+        * Add ``include_cutoff_time`` arg - control whether data at cutoff times are included in feature calculations (:pr:`959`)
     * Fixes
     * Changes
     * Documentation Changes

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -122,6 +122,7 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
                 progress_percent: percentage (float between 0 and 100) of total computation completed
                 time_elapsed: total time in seconds that has elapsed since start of call
 
+        include_cutoff_time (bool): If True, data at cutoff time are included in calculating features
     """
     assert (isinstance(features, list) and features != [] and
             all([isinstance(feature, FeatureBase) for feature in features])), \
@@ -450,7 +451,9 @@ def approximate_features(feature_set, cutoff_time, window, entityset,
             Window defining how much older than the cutoff time data
             can be to be included when calculating the feature. If None, all older data is used.
 
-        save_progress (str, optional): path to save intermediate computational results
+        include_cutoff_time (bool):
+            If True, data at cutoff time are included in calculating features
+
     '''
     approx_fms_trie = Trie(path_constructor=RelationshipPath)
 

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -122,7 +122,7 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
                 progress_percent: percentage (float between 0 and 100) of total computation completed
                 time_elapsed: total time in seconds that has elapsed since start of call
 
-        include_cutoff_time (bool): If True, data at cutoff time are included in calculating features
+        include_cutoff_time (bool): If True, data at cutoff times are included in feature calculations.
     """
     assert (isinstance(features, list) and features != [] and
             all([isinstance(feature, FeatureBase) for feature in features])), \
@@ -452,7 +452,7 @@ def approximate_features(feature_set, cutoff_time, window, entityset,
             can be to be included when calculating the feature. If None, all older data is used.
 
         include_cutoff_time (bool):
-            If True, data at cutoff time are included in calculating features
+            If True, data at cutoff times are included in feature calculations.
 
     '''
     approx_fms_trie = Trie(path_constructor=RelationshipPath)

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -122,7 +122,7 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
                 progress_percent: percentage (float between 0 and 100) of total computation completed
                 time_elapsed: total time in seconds that has elapsed since start of call
 
-        include_cutoff_time (bool): If True, data at cutoff times are included in feature calculations.
+        include_cutoff_time (bool): Include data at cutoff times in feature calculations. Defaults to ``True``.
     """
     assert (isinstance(features, list) and features != [] and
             all([isinstance(feature, FeatureBase) for feature in features])), \

--- a/featuretools/computational_backends/feature_set_calculator.py
+++ b/featuretools/computational_backends/feature_set_calculator.py
@@ -84,6 +84,9 @@ class FeatureSetCalculator(object):
 
             progress_callback (callable): function to be called with incremental progress updates
 
+            include_cutoff_time (bool): If True, data at cutoff time are included
+                in calculating features.
+
         Returns:
             pd.DataFrame : Pandas DataFrame of calculated feature values.
                 Indexed by instance_ids. Columns in same order as features
@@ -179,6 +182,10 @@ class FeatureSetCalculator(object):
                 ancestor_relationship_variables, parent_df).
                 ancestor_relationship_variables is the names of variables which
                 link the parent entity to its ancestors.
+
+            include_cutoff_time (bool): If True, data at cutoff time are included
+                in calculating features.
+
         """
         # Step 1: Get a dataframe for the given entity, filtered by the given
         # conditions.

--- a/featuretools/computational_backends/feature_set_calculator.py
+++ b/featuretools/computational_backends/feature_set_calculator.py
@@ -61,7 +61,7 @@ class FeatureSetCalculator(object):
         # total number of features (including dependencies) to be calculate
         self.num_features = sum(len(features1) + len(features2) for _, (_, features1, features2) in self.feature_set.feature_trie)
 
-    def run(self, instance_ids, progress_callback=None):
+    def run(self, instance_ids, progress_callback=None, include_cutoff_time=True):
         """
         Calculate values of features for the given instances of the target
         entity.
@@ -108,7 +108,8 @@ class FeatureSetCalculator(object):
                                             precalculated_trie=self.precalculated_features,
                                             filter_variable=target_entity.index,
                                             filter_values=instance_ids,
-                                            progress_callback=progress_callback)
+                                            progress_callback=progress_callback,
+                                            include_cutoff_time=include_cutoff_time)
 
         # The dataframe for the target entity should be stored at the root of
         # df_trie.
@@ -143,7 +144,8 @@ class FeatureSetCalculator(object):
                                        precalculated_trie,
                                        filter_variable, filter_values,
                                        parent_data=None,
-                                       progress_callback=None):
+                                       progress_callback=None,
+                                       include_cutoff_time=True):
         """
         Generate dataframes with features calculated for this node of the trie,
         and all descendant nodes. The dataframes will be stored in df_trie.
@@ -199,7 +201,8 @@ class FeatureSetCalculator(object):
                                     variable_id=query_variable,
                                     columns=columns,
                                     time_last=self.time_last,
-                                    training_window=self.training_window)
+                                    training_window=self.training_window,
+                                    include_cutoff_time=include_cutoff_time)
 
         # call to update timer
         progress_callback(0)
@@ -257,7 +260,8 @@ class FeatureSetCalculator(object):
                 filter_variable=sub_filter_variable,
                 filter_values=sub_filter_values,
                 parent_data=parent_data,
-                progress_callback=progress_callback)
+                progress_callback=progress_callback,
+                include_cutoff_time=include_cutoff_time)
 
         # Step 4: Calculate the features for this entity.
         #

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -224,6 +224,8 @@ class Entity(object):
             training_window (Timedelta, optional):
                 Window defining how much time before the cutoff time data
                 can be used when calculating features. If None, all data before cutoff time is used.
+            include_cutoff_time (bool):
+                If True, data at cutoff time are included in calculating features
 
         Returns:
             pd.DataFrame : instances that match constraints with ids in order of underlying dataframe

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -36,7 +36,8 @@ def dfs(entities=None,
         dask_kwargs=None,
         verbose=False,
         return_variable_types=None,
-        progress_callback=None):
+        progress_callback=None,
+        include_cutoff_time=True):
     '''Calculates a feature matrix and features given a dictionary of entities
     and a list of relationships.
 
@@ -259,7 +260,8 @@ def dfs(entities=None,
                                                   n_jobs=n_jobs,
                                                   dask_kwargs=dask_kwargs,
                                                   verbose=verbose,
-                                                  progress_callback=progress_callback)
+                                                  progress_callback=progress_callback,
+                                                  include_cutoff_time=include_cutoff_time)
     else:
         feature_matrix = calculate_feature_matrix(features,
                                                   entityset=entityset,
@@ -273,5 +275,6 @@ def dfs(entities=None,
                                                   n_jobs=n_jobs,
                                                   dask_kwargs=dask_kwargs,
                                                   verbose=verbose,
-                                                  progress_callback=progress_callback)
+                                                  progress_callback=progress_callback,
+                                                  include_cutoff_time=include_cutoff_time)
     return feature_matrix, features

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -203,7 +203,7 @@ def dfs(entities=None,
                 progress_percent: percentage (float between 0 and 100) of total computation completed
                 time_elapsed: total time in seconds that has elapsed since start of call
 
-        include_cutoff_time (bool): If True, data at cutoff times are included in feature calculations.
+        include_cutoff_time (bool): Include data at cutoff times in feature calculations. Defaults to ``True``.
 
     Examples:
         .. code-block:: python

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -203,6 +203,8 @@ def dfs(entities=None,
                 progress_percent: percentage (float between 0 and 100) of total computation completed
                 time_elapsed: total time in seconds that has elapsed since start of call
 
+        include_cutoff_time (bool): If True, data at cutoff time are included in calculating features
+
     Examples:
         .. code-block:: python
 

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -203,7 +203,7 @@ def dfs(entities=None,
                 progress_percent: percentage (float between 0 and 100) of total computation completed
                 time_elapsed: total time in seconds that has elapsed since start of call
 
-        include_cutoff_time (bool): If True, data at cutoff time are included in calculating features
+        include_cutoff_time (bool): If True, data at cutoff times are included in feature calculations.
 
     Examples:
         .. code-block:: python

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -315,7 +315,7 @@ def test_training_window(es):
     assert (feature_matrix[property_feature.get_name()] == prop_values).values.all()
     assert (feature_matrix[dagg.get_name()] == dagg_values).values.all()
 
-    # Case1. include_cutoff_time = False
+    # Case2. include_cutoff_time = False
     feature_matrix = calculate_feature_matrix([property_feature, dagg],
                                               es,
                                               cutoff_time=cutoff_time,

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -304,17 +304,30 @@ def test_training_window(es):
                                                   cutoff_time=cutoff_time,
                                                   training_window=Timedelta(2, 'observations'))
 
+    # Case1. include_cutoff_time = True
     feature_matrix = calculate_feature_matrix([property_feature, dagg],
                                               es,
                                               cutoff_time=cutoff_time,
-                                              training_window='2 hours')
+                                              training_window='2 hours',
+                                              include_cutoff_time=True)
     prop_values = [4, 5, 1]
     dagg_values = [3, 2, 1]
     assert (feature_matrix[property_feature.get_name()] == prop_values).values.all()
     assert (feature_matrix[dagg.get_name()] == dagg_values).values.all()
 
+    # Case1. include_cutoff_time = False
+    feature_matrix = calculate_feature_matrix([property_feature, dagg],
+                                              es,
+                                              cutoff_time=cutoff_time,
+                                              training_window='2 hours',
+                                              include_cutoff_time=False)
+    prop_values = [5, 5, 2]
+    dagg_values = [3, 2, 1]
+    assert (feature_matrix[property_feature.get_name()] == prop_values).values.all()
+    assert (feature_matrix[dagg.get_name()] == dagg_values).values.all()
 
-def test_training_window_overlap(es):
+
+def test_overlap_with_training_window(es):
     es.add_last_time_indexes()
 
     count_log = ft.Feature(
@@ -328,15 +341,62 @@ def test_training_window_overlap(es):
         'time': ['2011-04-09 10:30:00', '2011-04-09 10:40:00'],
     }).astype({'time': 'datetime64[ns]'})
 
+    # Case1. include_cutoff_time = True
     actual = ft.calculate_feature_matrix(
         features=[count_log],
         entityset=es,
         cutoff_time=cutoff_time,
         cutoff_time_in_index=True,
         training_window='10 minutes',
+        include_cutoff_time=True,
     )['COUNT(log)']
-
     np.testing.assert_array_equal(actual.values, [1, 9])
+
+    # Case2. include_cutoff_time = False
+    actual = ft.calculate_feature_matrix(
+        features=[count_log],
+        entityset=es,
+        cutoff_time=cutoff_time,
+        cutoff_time_in_index=True,
+        training_window='10 minutes',
+        include_cutoff_time=False,
+    )['COUNT(log)']
+    np.testing.assert_array_equal(actual.values, [0, 9])
+
+
+def test_overlap_without_training_window(es):
+    es.add_last_time_indexes()
+
+    count_log = ft.Feature(
+        base=es['log']['id'],
+        parent_entity=es['customers'],
+        primitive=Count,
+    )
+
+    cutoff_time = pd.DataFrame({
+        'id': [0, 0],
+        'time': ['2011-04-09 10:30:00', '2011-04-09 10:31:00'],
+    }).astype({'time': 'datetime64[ns]'})
+
+    # Case1. include_cutoff_time = True
+    actual = ft.calculate_feature_matrix(
+        features=[count_log],
+        entityset=es,
+        cutoff_time=cutoff_time,
+        cutoff_time_in_index=True,
+        include_cutoff_time=True,
+    )['COUNT(log)']
+    np.testing.assert_array_equal(actual.values, [1, 6])
+
+    # Case2. include_cutoff_time = False
+    actual = ft.calculate_feature_matrix(
+        features=[count_log],
+        entityset=es,
+        cutoff_time=cutoff_time,
+        cutoff_time_in_index=True,
+        include_cutoff_time=False,
+    )['COUNT(log)']
+    np.testing.assert_array_equal(actual.values, [0, 5])
 
 
 def test_training_window_recent_time_index(es):
@@ -379,16 +439,35 @@ def test_training_window_recent_time_index(es):
     times = [datetime(2011, 4, 9, 12, 31), datetime(2011, 4, 10, 11),
              datetime(2011, 4, 10, 13, 10, 1), datetime(2011, 4, 10, 1, 59, 59)]
     cutoff_time = pd.DataFrame({'time': times, 'instance_id': instance_ids})
+
+    # Case1. include_cutoff_time = True
     feature_matrix = calculate_feature_matrix(
         [property_feature, dagg],
         es,
         cutoff_time=cutoff_time,
-        training_window='2 hours'
+        training_window='2 hours',
+        include_cutoff_time=True,
     )
     prop_values = [4, 5, 1, 0]
+    assert (feature_matrix[property_feature.get_name()] == prop_values).values.all()
+
     dagg_values = [3, 2, 1, 3]
     feature_matrix.sort_index(inplace=True)
+    assert (feature_matrix[dagg.get_name()] == dagg_values).values.all()
+
+    # Case2. include_cutoff_time = False
+    feature_matrix = calculate_feature_matrix(
+        [property_feature, dagg],
+        es,
+        cutoff_time=cutoff_time,
+        training_window='2 hours',
+        include_cutoff_time=False,
+    )
+    prop_values = [5, 5, 1, 0]
     assert (feature_matrix[property_feature.get_name()] == prop_values).values.all()
+
+    dagg_values = [3, 2, 1, 3]
+    feature_matrix.sort_index(inplace=True)
     assert (feature_matrix[dagg.get_name()] == dagg_values).values.all()
 
 

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -327,7 +327,7 @@ def test_training_window(es):
     assert (feature_matrix[dagg.get_name()] == dagg_values).values.all()
 
 
-def test_overlap_with_training_window(es):
+def test_include_cutoff_time_with_training_window(es):
     es.add_last_time_indexes()
 
     count_log = ft.Feature(
@@ -364,7 +364,7 @@ def test_overlap_with_training_window(es):
     np.testing.assert_array_equal(actual.values, [0, 9])
 
 
-def test_overlap_without_training_window(es):
+def test_include_cutoff_time_without_training_window(es):
     es.add_last_time_indexes()
 
     count_log = ft.Feature(

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -185,17 +185,24 @@ def test_accepts_relative_training_window(datetime_es):
                                        cutoff_time=pd.Timestamp("2012-4-1 04:00"),
                                        training_window="3 months")
 
-    # Test case for leap years
-    feature_matrix_5, features_5 = dfs(entityset=datetime_es,
-                                       target_entity="transactions",
-                                       cutoff_time=pd.Timestamp("2012-2-29 04:00"),
-                                       training_window=Timedelta("1 year"))
-
     assert (feature_matrix.index == [1, 2, 3, 4, 5]).all()
     assert (feature_matrix_2.index == [1, 2, 3, 4]).all()
     assert (feature_matrix_3.index == [2, 3, 4]).all()
     assert (feature_matrix_4.index == [2, 3, 4]).all()
+
+    feature_matrix_5, features_5 = dfs(entityset=datetime_es,
+                                       target_entity="transactions",
+                                       cutoff_time=pd.Timestamp("2012-2-29 04:00"),
+                                       training_window=Timedelta("1 year"),
+                                       include_cutoff_time=True)
     assert (feature_matrix_5.index == [2]).all()
+
+    feature_matrix_5, features_5 = dfs(entityset=datetime_es,
+                                       target_entity="transactions",
+                                       cutoff_time=pd.Timestamp("2012-2-29 04:00"),
+                                       training_window=Timedelta("1 year"),
+                                       include_cutoff_time=False)
+    assert (feature_matrix_5.index == [1, 2]).all()
 
 
 def test_accepts_pd_timedelta_training_window(datetime_es):


### PR DESCRIPTION
Add `include_cutoff_time` arg to control whether data at cutoff times are included in feature calculations and prevent `traininig_window` overlapping

### Pull Request Description
There was a data overlapping problem when calculating the feature matrix: The data at cutoff time might be used both in calculating features and in calculating target values(#918 ). This could cause data cheating and affect the result as well. There was a trial to solve the issue (#930 ), but It still didn't solve the cheating problem. So, we decided to parameterize it to control whether data at cutoff times are included in feature calculations or not(#942 ) and this PR solves it.


