### PR TITLE
Add Dask support to EqualScalar and NotEqualScalar primitives

### DIFF
--- a/featuretools/primitives/standard/binary_transform.py
+++ b/featuretools/primitives/standard/binary_transform.py
@@ -274,6 +274,7 @@ class EqualScalar(TransformPrimitive):
     name = "equal_scalar"
     input_types = [Variable]
     return_type = Boolean
+    dask_compatible = True
 
     def __init__(self, value=None):
         self.value = value
@@ -329,12 +330,15 @@ class NotEqualScalar(TransformPrimitive):
     name = "not_equal_scalar"
     input_types = [Variable]
     return_type = Boolean
+    dask_compatible = True
 
     def __init__(self, value=None):
         self.value = value
 
     def get_function(self):
         def not_equal_scalar(vals):
+            if isinstance(vals, dd.core.Series):
+                return vals != self.value
             return pd.Series(vals) != self.value
         return not_equal_scalar
 

--- a/featuretools/primitives/standard/binary_transform.py
+++ b/featuretools/primitives/standard/binary_transform.py
@@ -1,6 +1,4 @@
-import dask.dataframe as dd
 import numpy as np
-import pandas as pd
 
 from featuretools.primitives.base.transform_primitive_base import (
     TransformPrimitive
@@ -281,9 +279,7 @@ class EqualScalar(TransformPrimitive):
 
     def get_function(self):
         def equal_scalar(vals):
-            if isinstance(vals, dd.core.Series):
-                return vals == self.value
-            return pd.Series(vals) == self.value
+            return vals == self.value
         return equal_scalar
 
     def generate_name(self, base_feature_names):
@@ -337,9 +333,7 @@ class NotEqualScalar(TransformPrimitive):
 
     def get_function(self):
         def not_equal_scalar(vals):
-            if isinstance(vals, dd.core.Series):
-                return vals != self.value
-            return pd.Series(vals) != self.value
+            return vals != self.value
         return not_equal_scalar
 
     def generate_name(self, base_feature_names):


### PR DESCRIPTION
Update `EqualScalar` and `NotEqualScalar` primitives to work properly with Dask.

Fixes #966 