### PR TITLE
Equal and NotEqual fix

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,7 @@ Changelog
     * Enhancements
         * Add ``get_default_aggregation_primitives`` and ``get_default_transform_primitives`` (:pr:`945`)
     * Fixes
+        * Fix errors with Equals and NotEquals primitives when comparing categoricals or different dtypes (:pr:`968`)
     * Changes
     * Documentation Changes
     * Testing Changes
@@ -13,7 +14,7 @@ Changelog
         * Update testing dependencies (:pr:`976`)
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`rwedge`
+    :user:`frances-h`, :user:`gsheni`, :user:`rwedge`
 
 **v0.14.0 Apr 30, 2020**
     * Enhancements

--- a/featuretools/primitives/standard/binary_transform.py
+++ b/featuretools/primitives/standard/binary_transform.py
@@ -248,7 +248,7 @@ class Equal(TransformPrimitive):
     commutative = True
 
     def get_function(self):
-        return np.equal
+        return pd.Series.eq
 
     def generate_name(self, base_feature_names):
         return "%s = %s" % (base_feature_names[0], base_feature_names[1])
@@ -301,7 +301,7 @@ class NotEqual(TransformPrimitive):
     commutative = True
 
     def get_function(self):
-        return np.not_equal
+        return pd.Series.ne
 
     def generate_name(self, base_feature_names):
         return "%s != %s" % (base_feature_names[0], base_feature_names[1])

--- a/featuretools/primitives/standard/binary_transform.py
+++ b/featuretools/primitives/standard/binary_transform.py
@@ -254,10 +254,7 @@ class Equal(TransformPrimitive):
                 categories = set(x_vals.cat.categories).union(set(y_vals.cat.categories))
                 x_vals = x_vals.cat.add_categories(categories.difference(set(x_vals.cat.categories)))
                 y_vals = y_vals.cat.add_categories(categories.difference(set(y_vals.cat.categories)))
-            if hasattr(x_vals, 'eq'):
-                return x_vals.eq(y_vals)
-            else:
-                return np.equal(x_vals, y_vals)
+            return x_vals.eq(y_vals)
 
         return equal
 
@@ -327,10 +324,7 @@ class NotEqual(TransformPrimitive):
                 categories = set(x_vals.cat.categories).union(set(y_vals.cat.categories))
                 x_vals = x_vals.cat.add_categories(categories.difference(set(x_vals.cat.categories)))
                 y_vals = y_vals.cat.add_categories(categories.difference(set(y_vals.cat.categories)))
-            if hasattr(x_vals, 'ne'):
-                return x_vals.ne(y_vals)
-            else:
-                return np.not_equal(x_vals, y_vals)
+            return x_vals.ne(y_vals)
 
         return not_equal
 

--- a/featuretools/primitives/standard/binary_transform.py
+++ b/featuretools/primitives/standard/binary_transform.py
@@ -298,12 +298,6 @@ class NotEqual(TransformPrimitive):
         whether each value in X is not equal to each corresponding
         value in Y.
 
-     Args:
-        strict_categories (bool): Deterimines how to compare Categorical
-        dtypes. If True, values are only conisidered equal if they have
-        the same categories. If False, categories are ignored when testing
-        equality. Defaults to False.
-
     Examples:
         >>> not_equal = NotEqual()
         >>> not_equal([2, 1, 2], [1, 2, 2]).tolist()
@@ -313,9 +307,6 @@ class NotEqual(TransformPrimitive):
     input_types = [Variable, Variable]
     return_type = Boolean
     commutative = True
-
-    def __init__(self, strict_categories=False):
-        self.strict_categories = strict_categories
 
     def get_function(self):
         def not_equal(x_vals, y_vals):

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -123,6 +123,46 @@ def test_make_trans_feat(es):
     assert v == 10
 
 
+def test_equal_categorical():
+    df = pd.DataFrame({
+        'id': range(4),
+        'value': pd.Categorical(['a', 'c', 'b', 'd']),
+        'value2': pd.Categorical(['a', 'b', 'a', 'd'])
+    })
+
+    es = ft.EntitySet('equal_test')
+    es.entity_from_dataframe('values', df, index='id')
+
+    f1 = ft.Feature([es['values']['value'], es['values']['value2']],
+                    primitive=Equal)
+
+    df = ft.calculate_feature_matrix(entityset=es, features=[f1])
+
+    assert set(es['values'].df['value'].cat.categories) != \
+           set(es['values'].df['value2'].cat.categories)
+    assert df['value = value2'].to_list() == [True, False, False, True]
+
+
+def test_not_equal_categorical():
+    df = pd.DataFrame({
+        'id': range(4),
+        'value': pd.Categorical(['a', 'c', 'b', 'd']),
+        'value2': pd.Categorical(['a', 'b', 'a', 'd'])
+    })
+
+    es = ft.EntitySet('not_equal_test')
+    es.entity_from_dataframe('values', df, index='id')
+
+    f1 = ft.Feature([es['values']['value'], es['values']['value2']],
+                    primitive=NotEqual)
+
+    df = ft.calculate_feature_matrix(entityset=es, features=[f1])
+
+    assert set(es['values'].df['value'].cat.categories) != \
+           set(es['values'].df['value2'].cat.categories)
+    assert df['value != value2'].to_list() == [False, True, True, False]
+
+
 def test_diff(es):
     value = ft.Feature(es['log']['value'])
     customer_id_feat = ft.Feature(es['sessions']['customer_id'], entity=es['log'])

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -129,6 +129,7 @@ def simple_es():
         'id': range(4),
         'value': pd.Categorical(['a', 'c', 'b', 'd']),
         'value2': pd.Categorical(['a', 'b', 'a', 'd']),
+        'object': ['time1', 'time2', 'time3', 'time4'],
         'datetime': pd.Series([pd.Timestamp('2001-01-01'),
                                pd.Timestamp('2001-01-02'),
                                pd.Timestamp('2001-01-03'),
@@ -153,16 +154,16 @@ def test_equal_categorical(simple_es):
 
 
 def test_equal_different_dtypes(simple_es):
-    f1 = ft.Feature([simple_es['values']['value'], simple_es['values']['datetime']],
+    f1 = ft.Feature([simple_es['values']['object'], simple_es['values']['datetime']],
                     primitive=Equal)
-    f2 = ft.Feature([simple_es['values']['datetime'], simple_es['values']['value']],
+    f2 = ft.Feature([simple_es['values']['datetime'], simple_es['values']['object']],
                     primitive=Equal)
 
     # verify that equals works for different dtypes regardless of order
     df = ft.calculate_feature_matrix(entityset=simple_es, features=[f1, f2])
 
-    assert df['value = datetime'].to_list() == [False, False, False, False]
-    assert df['datetime = value'].to_list() == [False, False, False, False]
+    assert df['object = datetime'].to_list() == [False, False, False, False]
+    assert df['datetime = object'].to_list() == [False, False, False, False]
 
 
 def test_not_equal_categorical(simple_es):
@@ -177,16 +178,16 @@ def test_not_equal_categorical(simple_es):
 
 
 def test_not_equal_different_dtypes(simple_es):
-    f1 = ft.Feature([simple_es['values']['value'], simple_es['values']['datetime']],
+    f1 = ft.Feature([simple_es['values']['object'], simple_es['values']['datetime']],
                     primitive=NotEqual)
-    f2 = ft.Feature([simple_es['values']['datetime'], simple_es['values']['value']],
+    f2 = ft.Feature([simple_es['values']['datetime'], simple_es['values']['object']],
                     primitive=NotEqual)
 
     # verify that equals works for different dtypes regardless of order
     df = ft.calculate_feature_matrix(entityset=simple_es, features=[f1, f2])
     print(df)
-    assert df['value != datetime'].to_list() == [True, True, True, True]
-    assert df['datetime != value'].to_list() == [True, True, True, True]
+    assert df['object != datetime'].to_list() == [True, True, True, True]
+    assert df['datetime != object'].to_list() == [True, True, True, True]
 
 
 def test_diff(es):

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -139,7 +139,7 @@ def test_equal_categorical():
     df = ft.calculate_feature_matrix(entityset=es, features=[f1])
 
     assert set(es['values'].df['value'].cat.categories) != \
-           set(es['values'].df['value2'].cat.categories)
+        set(es['values'].df['value2'].cat.categories)
     assert df['value = value2'].to_list() == [True, False, False, True]
 
 
@@ -159,7 +159,7 @@ def test_not_equal_categorical():
     df = ft.calculate_feature_matrix(entityset=es, features=[f1])
 
     assert set(es['values'].df['value'].cat.categories) != \
-           set(es['values'].df['value2'].cat.categories)
+        set(es['values'].df['value2'].cat.categories)
     assert df['value != value2'].to_list() == [False, True, True, False]
 
 


### PR DESCRIPTION
Resolves #922 and #944

- Force categories of categoricals to match
- Use native `.eq` instead of `numpy.equal`
