### PR TITLE
Support numeric time index for Dask entityset

### DIFF
--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -429,25 +429,20 @@ def calculate_chunk(cutoff_time, chunk_size, feature_set, entityset, approximate
             else:
                 # all rows have same cutoff time. set time and add passed columns
                 num_rows = len(ids)
+                if len(pass_columns) > 0:
+                    pass_through = group[['instance_id', cutoff_df_time_var] + pass_columns]
+                    pass_through.rename(columns={'instance_id': id_name,
+                                                 cutoff_df_time_var: 'time'},
+                                        inplace=True)
                 if isinstance(_feature_matrix, pd.DataFrame):
                     time_index = pd.Index([time_last] * num_rows, name='time')
                     _feature_matrix = _feature_matrix.set_index(time_index, append=True)
                     if len(pass_columns) > 0:
-                        pass_through = group[['instance_id', cutoff_df_time_var] + pass_columns]
-                        pass_through.rename(columns={'instance_id': id_name,
-                                                     cutoff_df_time_var: 'time'},
-                                            inplace=True)
                         pass_through.set_index([id_name, 'time'], inplace=True)
                         for col in pass_columns:
                             _feature_matrix[col] = pass_through[col]
                 elif isinstance(_feature_matrix, dd.core.DataFrame) and (len(pass_columns) > 0):
                     _feature_matrix['time'] = time_last
-                    if isinstance(time_last, pd.Timestamp):
-                        _feature_matrix['time'] = dd.to_datetime(_feature_matrix['time'])
-                    pass_through = group[['instance_id', cutoff_df_time_var] + pass_columns]
-                    pass_through.rename(columns={'instance_id': id_name,
-                                                 cutoff_df_time_var: 'time'},
-                                        inplace=True)
                     for col in pass_columns:
                         pass_df = dd.from_pandas(pass_through[[id_name, 'time', col]], npartitions=_feature_matrix.npartitions)
                         _feature_matrix = _feature_matrix.merge(pass_df)

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -445,7 +445,7 @@ def calculate_chunk(cutoff_time, chunk_size, feature_set, entityset, approximate
                     _feature_matrix['time'] = time_last
                     for col in pass_columns:
                         pass_df = dd.from_pandas(pass_through[[id_name, 'time', col]], npartitions=_feature_matrix.npartitions)
-                        _feature_matrix = _feature_matrix.merge(pass_df)
+                        _feature_matrix = _feature_matrix.merge(pass_df, how="outer")
                     _feature_matrix = _feature_matrix.drop(columns=['time'])
 
             feature_matrix.append(_feature_matrix)

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -442,7 +442,8 @@ def calculate_chunk(cutoff_time, chunk_size, feature_set, entityset, approximate
                             _feature_matrix[col] = pass_through[col]
                 elif isinstance(_feature_matrix, dd.core.DataFrame) and (len(pass_columns) > 0):
                     _feature_matrix['time'] = time_last
-                    _feature_matrix['time'] = dd.to_datetime(_feature_matrix['time'])
+                    if isinstance(time_last, pd.Timestamp):
+                        _feature_matrix['time'] = dd.to_datetime(_feature_matrix['time'])
                     pass_through = group[['instance_id', cutoff_df_time_var] + pass_columns]
                     pass_through.rename(columns={'instance_id': id_name,
                                                  cutoff_df_time_var: 'time'},

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -86,49 +86,6 @@ def datetime_es():
     return datetime_es
 
 
-@pytest.fixture
-def dask_es():
-    cards_df = pd.DataFrame({"id": [1, 2, 3, 4, 5]})
-    cards_df = dd.from_pandas(cards_df, npartitions=2)
-
-    transactions_df = pd.DataFrame({"id": [1, 2, 3, 4, 5],
-                                    "card_id": [1, 1, 5, 1, 5],
-                                    "transaction_time": pd.to_datetime([
-                                        '2011-2-28 04:00', '2012-2-28 05:00',
-                                        '2012-2-29 06:00', '2012-3-1 08:00',
-                                        '2014-4-1 10:00']),
-                                    "fraud": [True, False, False, False, True]})
-    transactions_df = dd.from_pandas(transactions_df, npartitions=2)
-
-    cards_vtypes = {
-        'id': vtypes.Index
-    }
-
-    transactions_vtypes = {
-        'id': vtypes.Index,
-        'card_id': vtypes.Id,
-        'transaction_time': vtypes.Datetime,
-        'fraud': vtypes.Boolean
-    }
-
-    dask_es = EntitySet(id="fraud_data")
-    dask_es = dask_es.entity_from_dataframe(entity_id="transactions",
-                                            dataframe=transactions_df,
-                                            index="id",
-                                            time_index="transaction_time",
-                                            variable_types=transactions_vtypes)
-
-    dask_es = dask_es.entity_from_dataframe(entity_id="cards",
-                                            dataframe=cards_df,
-                                            index="id",
-                                            variable_types=cards_vtypes)
-
-    relationship = Relationship(dask_es["cards"]["id"], dask_es["transactions"]["card_id"])
-    dask_es = dask_es.add_relationship(relationship)
-    dask_es.add_last_time_indexes()
-    return dask_es
-
-
 def test_accepts_cutoff_time_df(entities, relationships):
     cutoff_times_df = pd.DataFrame({"instance_id": [1, 2, 3],
                                     "time": [10, 12, 15]})


### PR DESCRIPTION
Previously time columns were always cast to datetime for Dask entities during DFS. This caused an issue with a numeric time index. This PR fixes that issue.

Fixes #991 