### PR TITLE
Fix error if target entity time index is 'time' or index is 'instance_id'

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 **Future Release**
     * Enhancements
         * Add ``get_default_aggregation_primitives`` and ``get_default_transform_primitives`` (:pr:`945`)
-        * Allow cutoff time dataframe columns to be in any order (:pr:`969`)
+        * Allow cutoff time dataframe columns to be in any order (:pr:`969`, :pr:`995`)
         * Add Age primitive, and make it a default transform primitive for DFS (:pr:`987`)
         * Add ``include_cutoff_time`` arg - control whether data at cutoff times are included in feature calculations (:pr:`959`)
     * Fixes

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -181,11 +181,12 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
         cutoff_time.rename(columns={target_entity.time_index: "time"}, inplace=True)
 
     # Make sure user supplies only one valid name for instance id and time columns
-    if "instance_id" in cutoff_time.columns and target_entity.index in cutoff_time.columns:
+    if "instance_id" in cutoff_time.columns and target_entity.index in cutoff_time.columns and \
+            "instance_id" != target_entity.index:
         raise AttributeError('Cutoff time DataFrame cannot contain both a column named "instance_id" and a column'
                              ' with the same name as the target entity index')
     if "time" in cutoff_time.columns and target_entity.time_index in cutoff_time.columns and \
-        "time" != target_entity.time_index:
+            "time" != target_entity.time_index:
         raise AttributeError('Cutoff time DataFrame cannot contain both a column named "time" and a column'
                              ' with the same name as the target entity time index')
 

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -184,7 +184,8 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
     if "instance_id" in cutoff_time.columns and target_entity.index in cutoff_time.columns:
         raise AttributeError('Cutoff time DataFrame cannot contain both a column named "instance_id" and a column'
                              ' with the same name as the target entity index')
-    if "time" in cutoff_time.columns and target_entity.time_index in cutoff_time.columns:
+    if "time" in cutoff_time.columns and target_entity.time_index in cutoff_time.columns and \
+        "time" != target_entity.time_index:
         raise AttributeError('Cutoff time DataFrame cannot contain both a column named "time" and a column'
                              ' with the same name as the target entity time index')
 


### PR DESCRIPTION
Add additional checks in case entity index is `instance_id` or entity time index is `time`

Fixes #994 
