### PR TITLE
Remove unnecessary pd.Series calls in primitives

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,14 +2,16 @@
 
 Changelog
 ---------
-.. **Future Release**
+**Future Release**
     * Enhancements
     * Fixes
     * Changes
+        * Remove unnecessary ``pd.Series`` calls from primitives (:pr:`1020`)
     * Documentation Changes
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
+    :user:`thehomebrewnerd`
 
 **v0.16.0 June 5, 2020**
     * Enhancements

--- a/featuretools/primitives/standard/transform_primitive.py
+++ b/featuretools/primitives/standard/transform_primitive.py
@@ -38,7 +38,7 @@ class IsNull(TransformPrimitive):
             if isinstance(array, dd.Series):
                 return dd.Series.isnull(array)
             else:
-                return pd.isnull(pd.Series(array))
+                return pd.isnull(array)
         return isnull
 
 
@@ -388,7 +388,7 @@ class TimeSince(TransformPrimitive):
         ...          datetime(2019, 3, 1, 0, 0, 1, 0),
         ...          datetime(2019, 3, 1, 0, 2, 0, 0)]
         >>> cutoff_time = datetime(2019, 3, 1, 0, 0, 0, 0)
-        >>> values = time_since(array=times, time=cutoff_time)
+        >>> values = time_since(times, time=cutoff_time)
         >>> list(map(int, values))
         [0, -1, -120]
 
@@ -400,7 +400,7 @@ class TimeSince(TransformPrimitive):
         ...          datetime(2019, 3, 1, 0, 0, 1, 0),
         ...          datetime(2019, 3, 1, 0, 2, 0, 0)]
         >>> cutoff_time = datetime(2019, 3, 1, 0, 0, 0, 0)
-        >>> values = time_since_nano(array=times, time=cutoff_time)
+        >>> values = time_since_nano(times, time=cutoff_time)
         >>> list(map(lambda x: int(round(x)), values))
         [-1000, -1000000000, -120000000000]
     """
@@ -415,8 +415,6 @@ class TimeSince(TransformPrimitive):
 
     def get_function(self):
         def pd_time_since(array, time):
-            if isinstance(array, list):
-                array = pd.Series(array)
             return convert_time_units((time - array).dt.total_seconds(), self.unit)
         return pd_time_since
 
@@ -440,10 +438,7 @@ class IsIn(TransformPrimitive):
 
     def get_function(self):
         def pd_is_in(array):
-            if isinstance(array, dd.Series):
-                return array.isin(self.list_of_outputs or [])
-            else:
-                return pd.Series(array).isin(self.list_of_outputs or [])
+            return array.isin(self.list_of_outputs or [])
         return pd_is_in
 
     def generate_name(self, base_feature_names):
@@ -539,7 +534,7 @@ class Percentile(TransformPrimitive):
     return_type = Numeric
 
     def get_function(self):
-        return lambda array: pd.Series(array).rank(pct=True)
+        return lambda array: array.rank(pct=True)
 
 
 class Latitude(TransformPrimitive):
@@ -561,7 +556,7 @@ class Latitude(TransformPrimitive):
         def latitude(latlong):
             if latlong.hasnans:
                 latlong = replace_latlong_nan(latlong)
-            return pd.Series(x[0] for x in latlong)
+            return latlong.map(lambda x: x[0])
         return latitude
 
 
@@ -584,7 +579,7 @@ class Longitude(TransformPrimitive):
         def longitude(latlong):
             if latlong.hasnans:
                 latlong = replace_latlong_nan(latlong)
-            return pd.Series(x[1] for x in latlong)
+            return latlong.map(lambda x: x[1])
         return longitude
 
 

--- a/featuretools/tests/primitive_tests/test_transform_primitive.py
+++ b/featuretools/tests/primitive_tests/test_transform_primitive.py
@@ -10,9 +10,9 @@ from featuretools.primitives import Age, TimeSince
 def test_time_since():
     time_since = TimeSince()
     # class datetime.datetime(year, month, day[, hour[, minute[, second[, microsecond[,
-    times = [datetime(2019, 3, 1, 0, 0, 0, 1),
-             datetime(2019, 3, 1, 0, 0, 1, 0),
-             datetime(2019, 3, 1, 0, 2, 0, 0)]
+    times = pd.Series([datetime(2019, 3, 1, 0, 0, 0, 1),
+                       datetime(2019, 3, 1, 0, 0, 1, 0),
+                       datetime(2019, 3, 1, 0, 2, 0, 0)])
     cutoff_time = datetime(2019, 3, 1, 0, 0, 0, 0)
     values = time_since(array=times, time=cutoff_time)
 
@@ -34,9 +34,9 @@ def test_time_since():
     values = time_since(array=times, time=cutoff_time)
     assert(list(map(int, values)) == [0, 0, 0])
 
-    times_y = [datetime(2019, 3, 1, 0, 0, 0, 1),
-               datetime(2020, 3, 1, 0, 0, 1, 0),
-               datetime(2017, 3, 1, 0, 0, 0, 0)]
+    times_y = pd.Series([datetime(2019, 3, 1, 0, 0, 0, 1),
+                         datetime(2020, 3, 1, 0, 0, 1, 0),
+                         datetime(2017, 3, 1, 0, 0, 0, 0)])
 
     time_since = TimeSince(unit='Years')
     values = time_since(array=times_y, time=cutoff_time)

--- a/featuretools/utils/entity_utils.py
+++ b/featuretools/utils/entity_utils.py
@@ -214,4 +214,4 @@ def col_is_datetime(col):
 
 def replace_latlong_nan(values):
     """replace a single `NaN` value with a tuple: `(np.nan, np.nan)`"""
-    return np.where(values.isnull(), pd.Series([(np.nan, np.nan)] * len(values)), values)
+    return values.where(values.notnull(), pd.Series([(np.nan, np.nan)] * len(values)))


### PR DESCRIPTION
Fixes #562 

Remove redundant `pd.Series` calls from primitives.

In order to remove the call from `Latitude` and `Longitude` primitives, the list comprehension inside the previous `pd.Series` call was replaces with a `.map()` operation. Performance testing indicated the new operation is approximately 15% faster than the previous list comprehension. This update also required an update to the `replace_latlong_nan` helper function to return a pandas Series instead of a numpy array.