### PR TITLE
Refactor cutoff times

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -8,6 +8,7 @@ Changelog
         * Improve warnings when using a Dask dataframe for cutoff times (:pr:`1026`)
     * Changes
         * Remove unnecessary ``pd.Series`` and ``pd.DatetimeIndex`` calls from primitives (:pr:`1020`, :pr:`1024`)
+        * Improve cutoff time handling when a single value or no value is passed (:pr:`1028`)
     * Documentation Changes
         * Remove featuretools enterprise from documentation (:pr:`1022`)
     * Testing Changes

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -171,6 +171,9 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
                                             include_cutoff_time=include_cutoff_time)
             instance_ids = df[index_var]
 
+        if isinstance(instance_ids, dd.Series):
+            instance_ids = instance_ids.compute()
+
         # convert list or range object into series
         if not isinstance(instance_ids, pd.Series) and not isinstance(instance_ids, dd.Series):
             instance_ids = pd.Series(instance_ids)

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -149,6 +149,9 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
     cutoff_time = _validate_cutoff_time(cutoff_time, target_entity)
 
     if isinstance(cutoff_time, pd.DataFrame):
+        if instance_ids:
+            msg = "Passing 'instance_ids' is valid only if 'cutoff_time' is a single value or None - ignoring"
+            warnings.warn(msg)
         pass_columns = [col for col in cutoff_time.columns if col not in ['instance_id', 'time']]
         # make sure dtype of instance_id in cutoff time
         # is same as column it references

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -336,8 +336,9 @@ def calculate_chunk(cutoff_time, chunk_size, feature_set, entityset, approximate
         calculator = FeatureSetCalculator(entityset,
                                           feature_set,
                                           time_last)
-
-        _feature_matrix = calculator.run(ids, progress_callback=update_progress_callback, include_cutoff_time=include_cutoff_time)
+        _feature_matrix = calculator.run(ids,
+                                         progress_callback=update_progress_callback,
+                                         include_cutoff_time=include_cutoff_time)
         if isinstance(_feature_matrix, pd.DataFrame):
             time_index = pd.Index([time_last] * len(ids), name='time')
             _feature_matrix = _feature_matrix.set_index(time_index, append=True)

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -225,7 +225,7 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
 
     if approximate is not None:
         # If there are approximated aggs, bin times
-        binned_cutoff_time = bin_cutoff_times(cutoff_time.copy(), approximate)
+        binned_cutoff_time = bin_cutoff_times(cutoff_time, approximate)
 
         # Think about collisions: what if original time is a feature
         binned_cutoff_time[target_time] = cutoff_time[cutoff_df_time_var]
@@ -504,7 +504,7 @@ def approximate_features(feature_set, cutoff_time, window, entityset,
 
     target_time_colname = 'target_time'
     cutoff_time[target_time_colname] = cutoff_time['time']
-    approx_cutoffs = bin_cutoff_times(cutoff_time.copy(), window)
+    approx_cutoffs = bin_cutoff_times(cutoff_time, window)
     cutoff_df_time_var = 'time'
     cutoff_df_instance_var = 'instance_id'
     # should this order be by dependencies so that calculate_feature_matrix

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -335,7 +335,8 @@ def calculate_chunk(cutoff_time, chunk_size, feature_set, entityset, approximate
         ids = ids.sort_values()
         calculator = FeatureSetCalculator(entityset,
                                           feature_set,
-                                          time_last)
+                                          time_last,
+                                          training_window=training_window)
         _feature_matrix = calculator.run(ids,
                                          progress_callback=update_progress_callback,
                                          include_cutoff_time=include_cutoff_time)

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -171,6 +171,7 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
                                             include_cutoff_time=include_cutoff_time)
             instance_ids = df[index_var]
 
+        # convert list or range object into series
         if not isinstance(instance_ids, pd.Series) and not isinstance(instance_ids, dd.Series):
             instance_ids = pd.Series(instance_ids)
 

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -284,6 +284,8 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
                 feature_matrix = feature_matrix.reindex(
                     pd.MultiIndex.from_frame(cutoff_time[["instance_id", "time"]],
                                              names=feature_matrix.index.names))
+            else:
+                feature_matrix = feature_matrix.reindex(cutoff_time[1], level=0)
             if not cutoff_time_in_index:
                 feature_matrix.reset_index(level='time', drop=True, inplace=True)
 

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -188,9 +188,9 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
     # Approximate provides no benefit with a single cutoff time, so ignore it
     if isinstance(cutoff_time, tuple) and approximate is not None:
         msg = "Using approximate with a single cutoff_time value or no cutoff_time " \
-            "provides no benefit - ignoring"
+            "provides no computational efficiency benefit"
         warnings.warn(msg)
-        approximate = None
+        cutoff_time = pd.DataFrame({"instance_id": cutoff_time[1], "time": [cutoff_time[0]] * len(cutoff_time[1])})
 
     feature_set = FeatureSet(features)
 

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -178,6 +178,13 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
 
     _check_cutoff_time_type(cutoff_time, entityset.time_type)
 
+    # Approximate provides no benefit with a single cutoff time, so ignore it
+    if isinstance(cutoff_time, tuple) and approximate is not None:
+        msg = "Using approximate with a single cutoff_time value or no cutoff_time " \
+            "provides no benefit - ignoring"
+        warnings.warn(msg)
+        approximate = None
+
     feature_set = FeatureSet(features)
 
     # Get features to approximate

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -333,9 +333,6 @@ def calculate_chunk(cutoff_time, chunk_size, feature_set, entityset, approximate
 
         time_last = cutoff_time[0]
         ids = cutoff_time[1]
-        if isinstance(ids, dd.Series):
-            ids = ids.compute()
-        ids = ids.sort_values()
         calculator = FeatureSetCalculator(entityset,
                                           feature_set,
                                           time_last,

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -178,7 +178,7 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
             instance_ids = instance_ids.compute()
 
         # convert list or range object into series
-        if not isinstance(instance_ids, pd.Series) and not isinstance(instance_ids, dd.Series):
+        if not isinstance(instance_ids, pd.Series):
             instance_ids = pd.Series(instance_ids)
 
         cutoff_time = (cutoff_time, instance_ids)

--- a/featuretools/computational_backends/utils.py
+++ b/featuretools/computational_backends/utils.py
@@ -21,8 +21,8 @@ from featuretools.variable_types import (
 logger = logging.getLogger('featuretools.computational_backend')
 
 
-def bin_cutoff_times(cuttoff_time, bin_size):
-    binned_cutoff_time = cuttoff_time.copy()
+def bin_cutoff_times(cutoff_time, bin_size):
+    binned_cutoff_time = cutoff_time.copy()
     if type(bin_size) == int:
         binned_cutoff_time['time'] = binned_cutoff_time['time'].apply(lambda x: x / bin_size * bin_size)
     else:

--- a/featuretools/computational_backends/utils.py
+++ b/featuretools/computational_backends/utils.py
@@ -11,7 +11,7 @@ import psutil
 from featuretools.entityset.relationship import RelationshipPath
 from featuretools.feature_base import AggregationFeature, DirectFeature
 from featuretools.utils import Trie
-from featuretools.utils.wrangle import _check_time_type, _check_timedelta
+from featuretools.utils.wrangle import _check_timedelta
 from featuretools.variable_types import (
     DatetimeTimeIndex,
     NumericTimeIndex,
@@ -263,12 +263,10 @@ def _check_cutoff_time_type(cutoff_time, es_time_type):
         cutoff_time_dtype = type(cutoff_time[0])
         numeric_types = [int, float]
         datetime_types = [datetime.datetime, pd.Timestamp]
-        cutoff_time_check = cutoff_time[0]
     else:
         cutoff_time_dtype = cutoff_time['time'].dtype.name
         numeric_types = PandasTypes._pandas_numerics
         datetime_types = PandasTypes._pandas_datetimes
-        cutoff_time_check = cutoff_time['time'].iloc[0]
 
     if es_time_type == NumericTimeIndex and cutoff_time_dtype not in numeric_types:
         raise TypeError("cutoff_time times must be numeric: try casting "

--- a/featuretools/computational_backends/utils.py
+++ b/featuretools/computational_backends/utils.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import numbers
 import os
 import warnings
 from functools import wraps
@@ -260,17 +261,18 @@ def _check_cutoff_time_type(cutoff_time, es_time_type):
     """
     # Check that cutoff_time time type matches entityset time type
     if isinstance(cutoff_time, tuple):
-        cutoff_time_dtype = type(cutoff_time[0])
-        numeric_types = [int, float]
+        cutoff_time_value = cutoff_time[0]
         datetime_types = [datetime.datetime, pd.Timestamp]
+        is_numeric = isinstance(cutoff_time_value, numbers.Number)
+        is_datetime = type(cutoff_time_value) in datetime_types
     else:
         cutoff_time_dtype = cutoff_time['time'].dtype.name
-        numeric_types = PandasTypes._pandas_numerics
-        datetime_types = PandasTypes._pandas_datetimes
+        is_numeric = cutoff_time_dtype in PandasTypes._pandas_numerics
+        is_datetime = cutoff_time_dtype in PandasTypes._pandas_datetimes
 
-    if es_time_type == NumericTimeIndex and cutoff_time_dtype not in numeric_types:
+    if es_time_type == NumericTimeIndex and not is_numeric:
         raise TypeError("cutoff_time times must be numeric: try casting "
                         "via pd.to_numeric()")
-    if es_time_type == DatetimeTimeIndex and cutoff_time_dtype not in datetime_types:
+    if es_time_type == DatetimeTimeIndex and not is_datetime:
         raise TypeError("cutoff_time times must be datetime type: try casting "
                         "via pd.to_datetime()")

--- a/featuretools/computational_backends/utils.py
+++ b/featuretools/computational_backends/utils.py
@@ -276,6 +276,3 @@ def _check_cutoff_time_type(cutoff_time, es_time_type):
     if es_time_type == DatetimeTimeIndex and cutoff_time_dtype not in datetime_types:
         raise TypeError("cutoff_time times must be datetime type: try casting "
                         "via pd.to_datetime()")
-
-    if _check_time_type(cutoff_time_check) is None:
-        raise ValueError("cutoff_time time values must be datetime or numeric")

--- a/featuretools/computational_backends/utils.py
+++ b/featuretools/computational_backends/utils.py
@@ -1,6 +1,4 @@
-import datetime
 import logging
-import numbers
 import os
 import warnings
 from functools import wraps
@@ -12,7 +10,7 @@ import psutil
 from featuretools.entityset.relationship import RelationshipPath
 from featuretools.feature_base import AggregationFeature, DirectFeature
 from featuretools.utils import Trie
-from featuretools.utils.wrangle import _check_timedelta
+from featuretools.utils.wrangle import _check_time_type, _check_timedelta
 from featuretools.variable_types import (
     DatetimeTimeIndex,
     NumericTimeIndex,
@@ -262,9 +260,9 @@ def _check_cutoff_time_type(cutoff_time, es_time_type):
     # Check that cutoff_time time type matches entityset time type
     if isinstance(cutoff_time, tuple):
         cutoff_time_value = cutoff_time[0]
-        datetime_types = [datetime.datetime, pd.Timestamp]
-        is_numeric = isinstance(cutoff_time_value, numbers.Number)
-        is_datetime = type(cutoff_time_value) in datetime_types
+        time_type = _check_time_type(cutoff_time_value)
+        is_numeric = time_type == NumericTimeIndex
+        is_datetime = time_type == DatetimeTimeIndex
     else:
         cutoff_time_dtype = cutoff_time['time'].dtype.name
         is_numeric = cutoff_time_dtype in PandasTypes._pandas_numerics

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -1,5 +1,3 @@
-import pandas as pd
-
 from featuretools.computational_backends import calculate_feature_matrix
 from featuretools.entityset import EntitySet
 from featuretools.synthesis.deep_feature_synthesis import DeepFeatureSynthesis
@@ -252,33 +250,18 @@ def dfs(entities=None,
     if features_only:
         return features
 
-    if isinstance(cutoff_time, pd.DataFrame):
-        feature_matrix = calculate_feature_matrix(features,
-                                                  entityset=entityset,
-                                                  cutoff_time=cutoff_time,
-                                                  training_window=training_window,
-                                                  approximate=approximate,
-                                                  cutoff_time_in_index=cutoff_time_in_index,
-                                                  save_progress=save_progress,
-                                                  chunk_size=chunk_size,
-                                                  n_jobs=n_jobs,
-                                                  dask_kwargs=dask_kwargs,
-                                                  verbose=verbose,
-                                                  progress_callback=progress_callback,
-                                                  include_cutoff_time=include_cutoff_time)
-    else:
-        feature_matrix = calculate_feature_matrix(features,
-                                                  entityset=entityset,
-                                                  cutoff_time=cutoff_time,
-                                                  instance_ids=instance_ids,
-                                                  training_window=training_window,
-                                                  approximate=approximate,
-                                                  cutoff_time_in_index=cutoff_time_in_index,
-                                                  save_progress=save_progress,
-                                                  chunk_size=chunk_size,
-                                                  n_jobs=n_jobs,
-                                                  dask_kwargs=dask_kwargs,
-                                                  verbose=verbose,
-                                                  progress_callback=progress_callback,
-                                                  include_cutoff_time=include_cutoff_time)
+    feature_matrix = calculate_feature_matrix(features,
+                                              entityset=entityset,
+                                              cutoff_time=cutoff_time,
+                                              instance_ids=instance_ids,
+                                              training_window=training_window,
+                                              approximate=approximate,
+                                              cutoff_time_in_index=cutoff_time_in_index,
+                                              save_progress=save_progress,
+                                              chunk_size=chunk_size,
+                                              n_jobs=n_jobs,
+                                              dask_kwargs=dask_kwargs,
+                                              verbose=verbose,
+                                              progress_callback=progress_callback,
+                                              include_cutoff_time=include_cutoff_time)
     return feature_matrix, features

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -516,6 +516,17 @@ def test_training_window(pd_es):
     assert (feature_matrix[property_feature.get_name()] == prop_values).values.all()
     assert (feature_matrix[dagg.get_name()] == dagg_values).values.all()
 
+    # Case4. include_cutoff_time = True with single cutoff time value
+    feature_matrix = calculate_feature_matrix([property_feature, dagg],
+                                              pd_es,
+                                              cutoff_time=pd.to_datetime("2011-04-10 10:40:00"),
+                                              training_window='2 days',
+                                              include_cutoff_time=True)
+    prop_values = [0, 10, 1]
+    dagg_values = [3, 3, 3]
+    assert (feature_matrix[property_feature.get_name()] == prop_values).values.all()
+    assert (feature_matrix[dagg.get_name()] == dagg_values).values.all()
+
 
 def test_training_window_overlap(pd_es):
     pd_es.add_last_time_indexes()

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -574,6 +574,27 @@ def test_include_cutoff_time_without_training_window(es):
     )['COUNT(log)']
     np.testing.assert_array_equal(actual.values, [0, 5])
 
+    # Case3. include_cutoff_time = True with single cutoff time value
+    actual = ft.calculate_feature_matrix(
+        features=[count_log],
+        entityset=es,
+        cutoff_time=pd.to_datetime("2011-04-09 10:31:00"),
+        instance_ids=[0],
+        cutoff_time_in_index=True,
+        include_cutoff_time=True,
+    )['COUNT(log)']
+    np.testing.assert_array_equal(actual.values, [6])
+
+    # Case4. include_cutoff_time = False with single cutoff time value
+    actual = ft.calculate_feature_matrix(
+        features=[count_log],
+        entityset=es,
+        cutoff_time=pd.to_datetime("2011-04-09 10:31:00"),
+        instance_ids=[0],
+        cutoff_time_in_index=True,
+        include_cutoff_time=False,
+    )['COUNT(log)']
+    np.testing.assert_array_equal(actual.values, [5])
 
 def test_approximate_dfeat_of_agg_on_target_include_cutoff_time(pd_es):
     agg_feat = ft.Feature(pd_es['log']['id'], parent_entity=pd_es['sessions'], primitive=Count)

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -1667,6 +1667,18 @@ def test_calls_progress_callback(mock_customer):
     assert np.isclose(mock_progress_callback.total_update, 100.0)
     assert np.isclose(mock_progress_callback.total_progress_percent, 100.0)
 
+    # test with cutoff time dataframe
+    mock_progress_callback = MockProgressCallback()
+    cutoff_time = pd.DataFrame({"instance_id":[1, 2, 3], 
+                                "time":[pd.to_datetime("2014-01-01 01:00:00"),
+                                        pd.to_datetime("2014-01-01 02:00:00"),
+                                        pd.to_datetime("2014-01-01 03:00:00")]})
+
+    ft.calculate_feature_matrix(features, entityset=es, cutoff_time=cutoff_time, progress_callback=mock_progress_callback)
+    assert np.isclose(mock_progress_callback.progress_history[-2], FEATURE_CALCULATION_PERCENTAGE * 100)
+    assert np.isclose(mock_progress_callback.total_update, 100.0)
+    assert np.isclose(mock_progress_callback.total_progress_percent, 100.0)
+
     # test with multiple jobs, pandas only
     if any(isinstance(entity.df, pd.DataFrame) for entity in es.entities):
         mock_progress_callback = MockProgressCallback()

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -1678,3 +1678,21 @@ def test_closes_tqdm(es):
         assert e.args[0] == "This primitive has errored"
     finally:
         assert len(tqdm._instances) == 0
+
+
+def test_approximate_with_single_cutoff_warns(pd_es):
+    property_feature = ft.Feature(pd_es['log']['value']) > 10
+
+    match = "Using approximate with a single cutoff_time value or no cutoff_time " \
+        "provides no benefit - ignoring"
+    # test single cutoff time
+    with pytest.warns(UserWarning, match=match):
+        calculate_feature_matrix([property_feature],
+                                 pd_es,
+                                 cutoff_time=pd.to_datetime('2020-01-01'),
+                                 approximate="1 day")
+    # test no cutoff time
+    with pytest.warns(UserWarning, match=match):
+        calculate_feature_matrix([property_feature],
+                                 pd_es,
+                                 approximate="1 day")

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -1669,10 +1669,10 @@ def test_calls_progress_callback(mock_customer):
 
     # test with cutoff time dataframe
     mock_progress_callback = MockProgressCallback()
-    cutoff_time = pd.DataFrame({"instance_id":[1, 2, 3], 
-                                "time":[pd.to_datetime("2014-01-01 01:00:00"),
-                                        pd.to_datetime("2014-01-01 02:00:00"),
-                                        pd.to_datetime("2014-01-01 03:00:00")]})
+    cutoff_time = pd.DataFrame({"instance_id": [1, 2, 3],
+                                "time": [pd.to_datetime("2014-01-01 01:00:00"),
+                                         pd.to_datetime("2014-01-01 02:00:00"),
+                                         pd.to_datetime("2014-01-01 03:00:00")]})
 
     ft.calculate_feature_matrix(features, entityset=es, cutoff_time=cutoff_time, progress_callback=mock_progress_callback)
     assert np.isclose(mock_progress_callback.progress_history[-2], FEATURE_CALCULATION_PERCENTAGE * 100)

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -1375,6 +1375,21 @@ def test_integer_time_index(int_es):
     assert (feature_matrix[property_feature.get_name()] == labels).values.all()
 
 
+def test_integer_time_index_single_cutoff_value(int_es):
+    labels = [False] * 3 + [True] * 2 + [False] * 4
+    property_feature = IdentityFeature(int_es['log']['value']) > 10
+
+    cutoff_times = [16, pd.Series([16])[0], 16.0, pd.Series([16.0])[0]]
+    for cutoff_time in cutoff_times:
+        feature_matrix = calculate_feature_matrix([property_feature],
+                                                  int_es,
+                                                  cutoff_time=cutoff_time,
+                                                  cutoff_time_in_index=True)
+        time_level_vals = feature_matrix.index.get_level_values(1).values
+        assert (time_level_vals == [16] * 9).all()
+        assert (feature_matrix[property_feature.get_name()] == labels).values.all()
+
+
 # TODO: add dask version of int_es
 def test_integer_time_index_datetime_cutoffs(int_es):
     times = [datetime.now()] * 17

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -510,10 +510,8 @@ def test_training_window(pd_es):
                                               pd_es,
                                               cutoff_time=pd.to_datetime("2011-04-09 10:40:00"),
                                               training_window='9 minutes',
-                                              # n_jobs=3,
                                               include_cutoff_time=False)
-    breakpoint()
-    prop_values = [4, 0, 0]
+    prop_values = [0, 4, 0]
     dagg_values = [3, 3, 3]
     assert (feature_matrix[property_feature.get_name()] == prop_values).values.all()
     assert (feature_matrix[dagg.get_name()] == dagg_values).values.all()

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -91,7 +91,7 @@ def test_calc_feature_matrix(es):
         feature_matrix = calculate_feature_matrix([1, 2, 3], es, cutoff_time=cutoff_time)
 
     error_text = "cutoff_time times must be datetime type: try casting via "\
-        "pd\\.to_datetime\\(cutoff_time\\['time'\\]\\)"
+        "pd\\.to_datetime\\(\\)"
     with pytest.raises(TypeError, match=error_text):
         calculate_feature_matrix([property_feature],
                                  es,
@@ -128,7 +128,7 @@ def test_calc_feature_matrix(es):
     # - can't tell if wrong/different all are false so can't check positional
 
 
-def test_cfm_fails_dask_cutoff_time(es):
+def test_cfm_warns_dask_cutoff_time(es):
     times = list([datetime(2011, 4, 9, 10, 30, i * 6) for i in range(5)] +
                  [datetime(2011, 4, 9, 10, 31, i * 9) for i in range(4)] +
                  [datetime(2011, 4, 9, 10, 40, 0)] +
@@ -1334,8 +1334,7 @@ def test_integer_time_index_datetime_cutoffs(int_es):
     cutoff_df = pd.DataFrame({'time': times, 'instance_id': range(17)})
     property_feature = IdentityFeature(int_es['log']['value']) > 10
 
-    error_text = "cutoff_time times must be numeric: try casting via "\
-        "pd\\.to_numeric\\(cutoff_time\\['time'\\]\\)"
+    error_text = "cutoff_time times must be numeric: try casting via pd\\.to_numeric\\(\\)"
     with pytest.raises(TypeError, match=error_text):
         calculate_feature_matrix([property_feature],
                                  int_es,

--- a/featuretools/variable_types/variable.py
+++ b/featuretools/variable_types/variable.py
@@ -7,7 +7,6 @@ from featuretools.utils.gen_utils import camel_to_snake, find_descendents
 class ClassNameDescriptor(object):
     """Descriptor to convert a class's name from camelcase to snakecase
     """
-
     def __get__(self, instance, class_):
         return camel_to_snake(class_.__name__)
 

--- a/featuretools/variable_types/variable.py
+++ b/featuretools/variable_types/variable.py
@@ -7,6 +7,7 @@ from featuretools.utils.gen_utils import camel_to_snake, find_descendents
 class ClassNameDescriptor(object):
     """Descriptor to convert a class's name from camelcase to snakecase
     """
+
     def __get__(self, instance, class_):
         return camel_to_snake(class_.__name__)
 


### PR DESCRIPTION
Refactor handling of cutoff times to avoid creating a large dataframe unnecessarily when using a single or `None` cutoff time value. Also, move cutoff time quality checks to `utils.py` instead of being included inside `calculate_feature_matrix.py`.

When cutoff time is a single value or `None` a cutoff time tuple is created that contains the cutoff time value along with the instance ids.

Fixes #961 