### PR TITLE
Error if relationship child variable is child entity index

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,6 +7,7 @@ Changelog
         * Add ``list_variable_types`` and ``graph_variable_types`` for Variable Types (:pr:`1013`)
     * Fixes
         * Improve warnings when using a Dask dataframe for cutoff times (:pr:`1026`)
+        * Error if attempting to add entityset relationship where child variable is also child index (:pr:`1034`)
     * Changes
         * Remove ``Feature.get_names`` (:pr:`1021`)
         * Remove unnecessary ``pd.Series`` and ``pd.DatetimeIndex`` calls from primitives (:pr:`1020`, :pr:`1024`)
@@ -18,7 +19,7 @@ Changelog
     * Testing Changes
 
     Thanks to the following people for contributing to this release:
-    :user:`tuethan1999`, :user:`kmax12`,  :user:`thehomebrewnerd`,  :user:`gsheni`
+    :user:`tuethan1999`, :user:`kmax12`,  :user:`thehomebrewnerd`,  :user:`gsheni`, :user:`frances-h`
         
 **Breaking Changes**
 

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -248,6 +248,8 @@ class EntitySet(object):
         # this is a new pair of entities
         child_e = relationship.child_entity
         child_v = relationship.child_variable.id
+        if child_e.index == child_v:
+            raise ValueError('Child variable cannot be index of child entity')
         parent_e = relationship.parent_entity
         parent_v = relationship.parent_variable.id
         if not isinstance(child_e[child_v], vtypes.Id):

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -249,7 +249,8 @@ class EntitySet(object):
         child_e = relationship.child_entity
         child_v = relationship.child_variable.id
         if child_e.index == child_v:
-            raise ValueError('Child variable cannot be index of child entity')
+            msg = "Unable to add relationship because child variable '{}' in '{}' is also its index"
+            raise ValueError(msg.format(child_v, child_e.id))
         parent_e = relationship.parent_entity
         parent_v = relationship.parent_variable.id
         if not isinstance(child_e[child_v], vtypes.Id):

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -145,7 +145,8 @@ def test_add_relationship_errors_child_v_index(es):
                              time_index='datetime')
 
     bad_relationship = ft.Relationship(es['log']['id'], es['log2']['id'])
-    with pytest.raises(ValueError, match='Child variable cannot be index of child entity'):
+    to_match = "Unable to add relationship because child variable 'id' in 'log2' is also its index"
+    with pytest.raises(ValueError, match=to_match):
         es.add_relationship(bad_relationship)
 
 


### PR DESCRIPTION
Error when adding an EntitySet relationship if the child variable is also the child entity's index
closes #1009 