### PR TITLE
have CircleCI fail if codecov fails to upload

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,7 +150,7 @@ jobs:
                 pytest featuretools/ -n 2 --cov=featuretools --cov-config=../.coveragerc
                 cd ../
                 cp unpacked_sdist/.coverage .coverage
-                codecov
+                codecov --required
       - unless:
           condition: << parameters.codecov >>
           steps:

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -16,9 +16,10 @@ Changelog
         * Remove featuretools enterprise from documentation (:pr:`1022`)
         * Add development install instructions to contributing.md (:pr:`1030`)
     * Testing Changes
+        * Add ``required`` flag to CircleCI codecov upload command (:pr:`1035`)
 
     Thanks to the following people for contributing to this release:
-    :user:`tuethan1999`, :user:`kmax12`,  :user:`thehomebrewnerd`,  :user:`gsheni`
+    :user:`tuethan1999`, :user:`kmax12`,  :user:`thehomebrewnerd`,  :user:`gsheni`, :user:`frances-h`
         
 **Breaking Changes**
 


### PR DESCRIPTION
Add `required` flag to codecov upload command so failure to upload triggers a CircleCI failure

Closes #997
