### PR TITLE
Fix feature visualization for features with '<' or '>' in name

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,7 +6,7 @@ Changelog
     * Enhancements
     * Fixes
         * Remove warnings.simplefilter in feature_set_calculator to un-silence warnings (:pr:`1053`)
-        * Fix feature visualzation for features with '>' or '<' in name (:pr:`1055`)
+        * Fix feature visualization for features with '>' or '<' in name (:pr:`1055`)
     * Changes
         * Make DFS match ``TimeSince`` primitive with all ``Datetime`` types (:pr:`1048`)
         * Change default branch to ``main`` (:pr:`1038`)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,7 @@ Changelog
     * Enhancements
     * Fixes
         * Remove warnings.simplefilter in feature_set_calculator to un-silence warnings (:pr:`1053`)
+        * Fix feature visualzation for features with '>' or '<' in name (:pr:`1055`)
     * Changes
         * Make DFS match ``TimeSince`` primitive with all ``Datetime`` types (:pr:`1048`)
         * Change default branch to ``main`` (:pr:`1038`)
@@ -16,7 +17,7 @@ Changelog
         * Implement automated process for checking critical dependencies (:pr:`1045`)        
     
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`systemshift`, :user:`monti-python`, :user:`thehomebrewnerd`
+    :user:`gsheni`, :user:`systemshift`, :user:`monti-python`, :user:`thehomebrewnerd`, :user:`frances-h`
 
 **v0.17.0 June 30, 2020**
     * Enhancements

--- a/featuretools/feature_base/feature_visualizer.py
+++ b/featuretools/feature_base/feature_visualizer.py
@@ -50,8 +50,8 @@ def graph_feature(feature, to_file=None):
     groupbys = []
 
     _, max_depth = get_feature_data(feature, entities, groupbys, edges, primitives, layer=0)
-    entities[feature.entity.id]['targets'].add(feature.get_name())
-
+    entities[feature.entity.id]['targets'].add(
+        feature.get_name().replace('>', '&gt;').replace('<', '&lt;'))
     for entity in entities:
         entity_name = '\u2605 {} (target)'.format(entity) if entity == feature.entity.id else entity
         entity_table = get_entity_table(entity_name, entities[entity])
@@ -105,13 +105,14 @@ def get_feature_data(feat, entities, groupbys, edges, primitives, layer=0):
 
     # if we've already explored this feat, continue
     feat_node = "{}:{}".format(feat.entity.id, feat_name)
-    if feat_name in entity_dict['vars'] or feat_name in entity_dict['feats']:
+    html_feat_name = feat_name.replace('>', '&gt;').replace('<', '&lt;')
+    if html_feat_name in entity_dict['vars'] or html_feat_name in entity_dict['feats']:
         return feat_node, layer
 
     if isinstance(feat, IdentityFeature):
-        entity_dict['vars'].add(feat_name)
+        entity_dict['vars'].add(html_feat_name)
     else:
-        entity_dict['feats'].add(feat_name)
+        entity_dict['feats'].add(html_feat_name)
     base_node = feat_node
 
     # 2) if multi-output, convert feature to generic base
@@ -188,7 +189,7 @@ def get_feature_data(feat, entities, groupbys, edges, primitives, layer=0):
 
 def add_entity(entity, entity_dict):
     entity_dict[entity.id] = {
-        'index': entity.index,
+        'index': entity.index.replace('>', '&gt;').replace('<', '&lt;'),
         'targets': set(),
         'vars': set(),
         'feats': set()

--- a/featuretools/feature_base/feature_visualizer.py
+++ b/featuretools/feature_base/feature_visualizer.py
@@ -53,6 +53,7 @@ def graph_feature(feature, to_file=None):
 
     _, max_depth = get_feature_data(feature, entities, groupbys, edges, primitives, layer=0)
     entities[feature.entity.id]['targets'].add(feature.get_name())
+
     for entity in entities:
         entity_name = '\u2605 {} (target)'.format(entity) if entity == feature.entity.id else entity
         entity_table = get_entity_table(entity_name, entities[entity])

--- a/featuretools/tests/primitive_tests/test_feature_visualizer.py
+++ b/featuretools/tests/primitive_tests/test_feature_visualizer.py
@@ -68,6 +68,20 @@ def test_transform(es):
         assert match in row
 
 
+def test_html_symbols(es, tmpdir):
+    output_path = str(tmpdir.join("test2.png"))
+    value = IdentityFeature(es['log']['value'])
+    gt = value > 5
+    lt = value < 5
+    ge = value >= 5
+    le = value <= 5
+
+    for feat in [gt, lt, ge, le]:
+        graph = graph_feature(feat, to_file=output_path).source
+        assert os.path.isfile(output_path)
+        assert feat.get_name() in graph
+
+
 def test_groupby_transform(es):
     feat = GroupByTransformFeature(es['customers']['age'], CumMax, es['customers']['cohort'])
     graph = graph_feature(feat).source

--- a/featuretools/tests/primitive_tests/test_feature_visualizer.py
+++ b/featuretools/tests/primitive_tests/test_feature_visualizer.py
@@ -69,14 +69,15 @@ def test_transform(es):
 
 
 def test_html_symbols(es, tmpdir):
-    output_path = str(tmpdir.join("test2.png"))
+    output_path_template = str(tmpdir.join("test{}.png"))
     value = IdentityFeature(es['log']['value'])
     gt = value > 5
     lt = value < 5
     ge = value >= 5
     le = value <= 5
 
-    for feat in [gt, lt, ge, le]:
+    for i, feat in enumerate([gt, lt, ge, le]):
+        output_path = output_path_template.format(i)
         graph = graph_feature(feat, to_file=output_path).source
         assert os.path.isfile(output_path)
         assert feat.get_name() in graph


### PR DESCRIPTION
Replace '>' and '<' in feature names with HTML escape characters to fix graphviz parsing error