### PR TITLE
Add more ignore branch filters to changelog check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -312,7 +312,11 @@ workflows:
           name: "changelog updated"
           filters:
             branches:
-              ignore: /^main?/
+              ignore:
+                - /^main?/
+                - /^v\d+\.\d+\.\d+$/
+                - /^dep-update-[a-f0-9]{7}$/
+                - /^more-changelog-ignore-cases$/
       - run_premium_primitives_tests_on_main:
           name: "run premium primitives tests on main"
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,7 +316,6 @@ workflows:
                 - /^main?/
                 - /^v\d+\.\d+\.\d+$/
                 - /^dep-update-[a-f0-9]{7}$/
-                - /^more-changelog-ignore-cases$/
       - run_premium_primitives_tests_on_main:
           name: "run premium primitives tests on main"
           filters:

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -15,9 +15,10 @@ Changelog
         * Add fixture for ``ft.demo.load_mock_customer`` (:pr:`1036`)
         * Refactor Dask test units (:pr:`1052`)
         * Implement automated process for checking critical dependencies (:pr:`1045`, :pr:`1054`)
+        * Don't run changelog check for release PRs or automated dependency PRs (:pr:`1057`)
     
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`systemshift`, :user:`monti-python`, :user:`thehomebrewnerd`
+    :user:`gsheni`, :user:`systemshift`, :user:`monti-python`, :user:`thehomebrewnerd`, :user:`rwedge`
 
 **v0.17.0 June 30, 2020**
     * Enhancements


### PR DESCRIPTION
Ignore the changelog update check for release PRs and dependency update prs

I initally tested the ignore filter list by adding a rule to ignore this branch and removing the rule after confirming the changelog test was not used.