### PR TITLE
Fix nlp-primitives installation in docs job

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 -r test-requirements.txt
+nlp_primitives>=0.3.0
 featuretools-sklearn-transformer >= 0.1.0
 codecov==2.1.0
 flake8==3.7.8
@@ -11,5 +12,4 @@ nbconvert==5.6.1
 nbsphinx==0.7.0
 Sphinx==3.0.3
 sphinx_rtd_theme==0.4.3
-nlp_primitives>=0.3.0
 autonormalize >= 1.0.1


### PR DESCRIPTION
Trying to remove  the warning found in output at https://docs.featuretools.com/en/stable/variables.html
```python-stacktrace
2020-07-16 14:17:32,113 featuretools - WARNING    Featuretools failed to load plugin nlp_primitives from library nlp_primitives. For a full stack trace, set logging to debug.
```