### PR TITLE
Make Dask transform test deterministic

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -19,6 +19,7 @@ Changelog
         * Refactor Dask test units (:pr:`1052`)
         * Implement automated process for checking critical dependencies (:pr:`1045`, :pr:`1054`)
         * Don't run changelog check for release PRs or automated dependency PRs (:pr:`1057`)
+        * Fix non-deterministic behavior in Dask test causing codecov issues (:pr:`1070`)
 
     Thanks to the following people for contributing to this release:
     :user:`gsheni`, :user:`systemshift`, :user:`monti-python`, :user:`thehomebrewnerd`, :user:`frances-h`, :user:`rwedge`

--- a/featuretools/tests/primitive_tests/test_dask_primitives.py
+++ b/featuretools/tests/primitive_tests/test_dask_primitives.py
@@ -1,3 +1,5 @@
+import random
+
 import pandas as pd
 
 import featuretools as ft
@@ -15,25 +17,36 @@ def test_transform(pd_es, dask_es):
     trans_list = primitives[primitives['type'] == 'transform']['name'].tolist()
     trans_primitives = [prim for prim in trans_list if prim not in UNSUPPORTED]
     agg_primitives = []
+    cutoff_time = pd.Timestamp("2019-01-05 04:00")
 
     assert pd_es == dask_es
+
+    # TODO: Update when issue #833 is closed to use max_features instead of random sampling
     # Run DFS using each entity as a target and confirm results match
     for entity in pd_es.entities:
-        fm, _ = ft.dfs(entityset=pd_es,
-                       target_entity=entity.id,
-                       trans_primitives=trans_primitives,
-                       agg_primitives=agg_primitives,
-                       cutoff_time=pd.Timestamp("2019-01-05 04:00"),
-                       max_depth=2,
-                       max_features=100)
+        features = ft.dfs(entityset=pd_es,
+                          target_entity=entity.id,
+                          trans_primitives=trans_primitives,
+                          agg_primitives=agg_primitives,
+                          max_depth=2,
+                          features_only=True)
 
-        dask_fm, _ = ft.dfs(entityset=dask_es,
-                            target_entity=entity.id,
-                            trans_primitives=trans_primitives,
-                            agg_primitives=agg_primitives,
-                            cutoff_time=pd.Timestamp("2019-01-05 04:00"),
-                            max_depth=2,
-                            max_features=100)
+        dask_features = ft.dfs(entityset=dask_es,
+                               target_entity=entity.id,
+                               trans_primitives=trans_primitives,
+                               agg_primitives=agg_primitives,
+                               max_depth=2,
+                               features_only=True)
+        assert features == dask_features
+
+        # Randomly sample up to 100 features to use to calculate feature matrix values to confirm
+        # output is the same between dask and pandas. Use random seed to make sure same features
+        # are tested each time. Not testing on all returned features due to long run times.
+        random.seed(0)
+        features = random.sample(features, min(100, len(features)))
+        fm = ft.calculate_feature_matrix(features=features, entityset=pd_es, cutoff_time=cutoff_time)
+        dask_fm = ft.calculate_feature_matrix(features=features, entityset=dask_es, cutoff_time=cutoff_time)
+
         # Use the same columns and make sure both indexes are sorted the same
         dask_computed_fm = dask_fm.compute().set_index(entity.index).loc[fm.index][fm.columns]
         pd.testing.assert_frame_equal(fm, dask_computed_fm)


### PR DESCRIPTION
The test `test_dask_primitives.py::test_transform` was not deterministic, causing a different set of features to be used from run to run. This resulted in small differences in code coverage between runs. This PR, updates this test to make sure the same set of features are always used.

Note: the root of this issue is that when using max_features, the same set of features are not always returned by dfs (see issue #833). The updates in this PR are only a needed as a temporary measure until #833 is fixed.