### PR TITLE
Warn user if primitives are unused during dfs

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 ---------
 **Future Release**
     * Enhancements
+        * Warn user if supplied primitives are not used during dfs (:pr:`1073`)
     * Fixes
         * Fix issue with missing instance ids and categorical entity index (:pr:`1050`)
         * Remove warnings.simplefilter in feature_set_calculator to un-silence warnings (:pr:`1053`)

--- a/featuretools/exceptions.py
+++ b/featuretools/exceptions.py
@@ -2,3 +2,9 @@ class UnknownFeature(Exception):
 
     def __init__(self, *args, **kwargs):
         Exception.__init__(self, *args, **kwargs)
+
+
+class UnusedPrimitiveWarning(Warning):
+
+    def __init__(self, *args, **kwargs):
+        Warning.__init__(self, *args, **kwargs)

--- a/featuretools/exceptions.py
+++ b/featuretools/exceptions.py
@@ -5,6 +5,4 @@ class UnknownFeature(Exception):
 
 
 class UnusedPrimitiveWarning(UserWarning):
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    pass

--- a/featuretools/exceptions.py
+++ b/featuretools/exceptions.py
@@ -4,7 +4,7 @@ class UnknownFeature(Exception):
         Exception.__init__(self, *args, **kwargs)
 
 
-class UnusedPrimitiveWarning(Warning):
+class UnusedPrimitiveWarning(UserWarning):
 
     def __init__(self, *args, **kwargs):
-        Warning.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -5,6 +5,7 @@ from featuretools.entityset import EntitySet
 from featuretools.feature_base import (
     AggregationFeature,
     DirectFeature,
+    FeatureOutputSlice,
     GroupByTransformFeature,
     TransformFeature
 )
@@ -332,13 +333,16 @@ def warn_unused_primitives(unused_primitives):
 
 def get_base_features(features):
     """Take a list of features and add all base features for any direct features"""
-    if any([isinstance(feature, DirectFeature) for feature in features]):
-        new_features = []
-        for feature in features:
-            if isinstance(feature, DirectFeature):
-                new_features.extend(feature.base_features)
-            else:
-                new_features.append(feature)
-        return get_base_features(new_features)
-    else:
+    updated = False
+    new_features = []
+    for feature in features:
+        if isinstance(feature, DirectFeature) or isinstance(feature, FeatureOutputSlice):
+            new_features.extend(feature.base_features)
+            updated = True
+        else:
+            new_features.append(feature)
+
+    if not updated:
         return features
+    else:
+        return get_base_features(new_features)

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -2,6 +2,7 @@ import warnings
 
 from featuretools.computational_backends import calculate_feature_matrix
 from featuretools.entityset import EntitySet
+from featuretools.exceptions import UnusedPrimitiveWarning
 from featuretools.feature_base import (
     AggregationFeature,
     FeatureOutputSlice,
@@ -309,7 +310,7 @@ def warn_unused_primitives(unused_primitives):
         "This may be caused by a using a value of max_depth that is too small, not setting interesting values, " + \
         "or it may indicate no compatible variable types for the primitive were found in the data."
 
-    warnings.warn(warning_msg)
+    warnings.warn(warning_msg, UnusedPrimitiveWarning)
 
 
 def _categorize_features(features):

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -316,15 +316,15 @@ def warn_unused_primitives(unused_primitives):
     trans_unused, agg_unused, groupby_unused, where_unused = unused_primitives
     unused_string = ""
     if trans_unused:
-        unused_string += " trans_primitives: {}".format(trans_unused)
+        unused_string += "  trans_primitives: {}\n".format(trans_unused)
     if agg_unused:
-        unused_string += " agg_primitives: {}".format(agg_unused)
+        unused_string += "  agg_primitives: {}\n".format(agg_unused)
     if groupby_unused:
-        unused_string += " groupby_trans_primitives: {}".format(groupby_unused)
+        unused_string += "  groupby_trans_primitives: {}\n".format(groupby_unused)
     if where_unused:
-        unused_string += " where_primitives: {}".format(where_unused)
+        unused_string += "  where_primitives: {}\n".format(where_unused)
 
-    warning_msg = "Some specified primitives were not used during DFS.{}. ".format(unused_string) + \
+    warning_msg = "Some specified primitives were not used during DFS:\n{}".format(unused_string) + \
         "This may be caused by a using a value of max_depth that is too small, not setting interesting values, " + \
         "or it may indicate no compatible variable types for the primitive were found in the data."
 

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -296,16 +296,14 @@ def get_unused_primitives(specified, features):
 
 
 def warn_unused_primitives(unused_primitives):
-    trans_unused, agg_unused, groupby_unused, where_unused = unused_primitives
+    messages = ["  trans_primitives: {}\n",
+                "  agg_primitives: {}\n",
+                "  groupby_trans_primitives: {}\n",
+                "  where_primitives: {}\n"]
     unused_string = ""
-    if trans_unused:
-        unused_string += "  trans_primitives: {}\n".format(trans_unused)
-    if agg_unused:
-        unused_string += "  agg_primitives: {}\n".format(agg_unused)
-    if groupby_unused:
-        unused_string += "  groupby_trans_primitives: {}\n".format(groupby_unused)
-    if where_unused:
-        unused_string += "  where_primitives: {}\n".format(where_unused)
+    for primitives, message in zip(unused_primitives, messages):
+        if primitives:
+            unused_string += message.format(primitives)
 
     warning_msg = "Some specified primitives were not used during DFS:\n{}".format(unused_string) + \
         "This may be caused by a using a value of max_depth that is too small, not setting interesting values, " + \

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -4,6 +4,7 @@ from featuretools.computational_backends import calculate_feature_matrix
 from featuretools.entityset import EntitySet
 from featuretools.feature_base import (
     AggregationFeature,
+    DirectFeature,
     GroupByTransformFeature,
     TransformFeature
 )
@@ -259,7 +260,9 @@ def dfs(entities=None,
     groupby_features = []
     where_features = []
 
-    for feature in features:
+    base_features = get_base_features(features)
+
+    for feature in base_features:
         if isinstance(feature, AggregationFeature):
             if feature.where:
                 where_features.append(feature)
@@ -325,3 +328,17 @@ def warn_unused_primitives(unused_primitives):
         "or it may indicate no compatible variable types for the primitive were found in the data."
 
     warnings.warn(warning_msg)
+
+
+def get_base_features(features):
+    """Take a list of features and add all base features for any direct features"""
+    if any([isinstance(feature, DirectFeature) for feature in features]):
+        new_features = []
+        for feature in features:
+            if isinstance(feature, DirectFeature):
+                new_features.extend(feature.base_features)
+            else:
+                new_features.append(feature)
+        return get_base_features(new_features)
+    else:
+        return features

--- a/featuretools/tests/latest_dependencies.txt
+++ b/featuretools/tests/latest_dependencies.txt
@@ -6,4 +6,4 @@ numpy==1.19.0
 pandas==1.0.5
 psutil==5.7.2
 scipy==1.5.1
-tqdm==4.47.0
+tqdm==4.48.0

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -313,8 +313,8 @@ def test_warns_with_unused_primitives(es):
     trans_primitives = ['num_characters', 'num_words', 'add_numeric']
     agg_primitives = [Max, 'min']
 
-    warning_text = "Some specified primitives were not used during DFS. " + \
-        "trans_primitives: ['add_numeric'] agg_primitives: ['max', 'min']. " + \
+    warning_text = "Some specified primitives were not used during DFS:\n" + \
+        "  trans_primitives: ['add_numeric']\n  agg_primitives: ['max', 'min']\n" + \
         "This may be caused by a using a value of max_depth that is too small, not setting interesting values, " + \
         "or it may indicate no compatible variable types for the primitive were found in the data."
 
@@ -339,8 +339,8 @@ def test_warns_with_unused_primitives(es):
 
 
 def test_warns_with_unused_where_primitives(es):
-    warning_text = "Some specified primitives were not used during DFS. " + \
-        "where_primitives: ['count', 'sum']. " + \
+    warning_text = "Some specified primitives were not used during DFS:\n" + \
+        "  where_primitives: ['count', 'sum']\n" + \
         "This may be caused by a using a value of max_depth that is too small, not setting interesting values, " + \
         "or it may indicate no compatible variable types for the primitive were found in the data."
 
@@ -350,13 +350,13 @@ def test_warns_with_unused_where_primitives(es):
             agg_primitives=['count'],
             where_primitives=['sum', 'count'],
             max_depth=1)
-
+    breakpoint()
     assert record[0].message.args[0] == warning_text
 
 
 def test_warns_with_unused_groupby_primitives(pd_es):
-    warning_text = "Some specified primitives were not used during DFS. " + \
-        "groupby_trans_primitives: ['cum_sum']. " + \
+    warning_text = "Some specified primitives were not used during DFS:\n" + \
+        "  groupby_trans_primitives: ['cum_sum']\n" + \
         "This may be caused by a using a value of max_depth that is too small, not setting interesting values, " + \
         "or it may indicate no compatible variable types for the primitive were found in the data."
 
@@ -388,8 +388,8 @@ def test_warns_with_unused_custom_primitives(pd_es):
 
     trans_primitives = [AboveTen]
 
-    warning_text = "Some specified primitives were not used during DFS. " + \
-        "trans_primitives: ['above_ten']. " + \
+    warning_text = "Some specified primitives were not used during DFS:\n" + \
+        "  trans_primitives: ['above_ten']\n" + \
         "This may be caused by a using a value of max_depth that is too small, not setting interesting values, " + \
         "or it may indicate no compatible variable types for the primitive were found in the data."
 
@@ -417,8 +417,8 @@ def test_warns_with_unused_custom_primitives(pd_es):
 
     agg_primitives = [MaxAboveTen]
 
-    warning_text = "Some specified primitives were not used during DFS. " + \
-        "agg_primitives: ['max_above_ten']. " + \
+    warning_text = "Some specified primitives were not used during DFS:\n" + \
+        "  agg_primitives: ['max_above_ten']\n" + \
         "This may be caused by a using a value of max_depth that is too small, not setting interesting values, " + \
         "or it may indicate no compatible variable types for the primitive were found in the data."
 

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -10,8 +10,16 @@ from featuretools.computational_backends.calculate_feature_matrix import (
     FEATURE_CALCULATION_PERCENTAGE
 )
 from featuretools.entityset import EntitySet, Relationship, Timedelta
-from featuretools.primitives import Max, Mean, Min, Sum
+from featuretools.primitives import (
+    Max,
+    Mean,
+    Min,
+    Sum,
+    make_agg_primitive,
+    make_trans_primitive
+)
 from featuretools.synthesis import dfs
+from featuretools.variable_types import Numeric
 
 
 @pytest.fixture(params=['pd_entities', 'dask_entities'])
@@ -235,28 +243,6 @@ def test_features_only(entities, relationships):
     assert len(features) > 0
 
 
-def test_dask_kwargs(pd_entities, relationships):
-    cutoff_times_df = pd.DataFrame({"instance_id": [1, 2, 3],
-                                    "time": [10, 12, 15]})
-    feature_matrix, features = dfs(entities=pd_entities,
-                                   relationships=relationships,
-                                   target_entity="transactions",
-                                   cutoff_time=cutoff_times_df)
-
-    with cluster() as (scheduler, [a, b]):
-        dask_kwargs = {'cluster': scheduler['address']}
-        feature_matrix_2, features_2 = dfs(entities=pd_entities,
-                                           relationships=relationships,
-                                           target_entity="transactions",
-                                           cutoff_time=cutoff_times_df,
-                                           dask_kwargs=dask_kwargs)
-
-    assert all(f1.unique_name() == f2.unique_name() for f1, f2 in zip(features, features_2))
-    for column in feature_matrix:
-        for x, y in zip(feature_matrix[column], feature_matrix_2[column]):
-            assert ((pd.isnull(x) and pd.isnull(y)) or (x == y))
-
-
 def test_accepts_relative_training_window(datetime_es):
     # TODO: Update to use Dask entities when issue #882 is closed
     feature_matrix, features = dfs(entityset=datetime_es,
@@ -323,6 +309,144 @@ def test_accepts_pd_dateoffset_training_window(datetime_es):
     assert (feature_matrix.index == feature_matrix_2.index).all()
 
 
+def test_warns_with_unused_primitives(es):
+    trans_primitives = ['num_characters', 'num_words', 'add_numeric']
+    agg_primitives = [Max, 'min']
+
+    warning_text = "Some specified primitives were not used during DFS. " + \
+        "trans_primitives: ['add_numeric'] agg_primitives: ['max', 'min']. " + \
+        "This may be caused by a using a value of max_depth that is too small, not setting interesting values, " + \
+        "or it may indicate no compatible variable types for the primitive were found in the data."
+
+    with pytest.warns(UserWarning) as record:
+        dfs(entityset=es,
+            target_entity='customers',
+            trans_primitives=trans_primitives,
+            agg_primitives=agg_primitives,
+            max_depth=1,
+            features_only=True)
+
+    assert record[0].message.args[0] == warning_text
+
+    # Should not raise a warning
+    with pytest.warns(None) as record:
+        dfs(entityset=es,
+            target_entity='customers',
+            trans_primitives=trans_primitives,
+            agg_primitives=agg_primitives,
+            max_depth=2,
+            features_only=True)
+
+    assert not record
+
+
+def test_warns_with_unused_where_primitives(es):
+    warning_text = "Some specified primitives were not used during DFS. " + \
+        "where_primitives: ['count', 'sum']. " + \
+        "This may be caused by a using a value of max_depth that is too small, not setting interesting values, " + \
+        "or it may indicate no compatible variable types for the primitive were found in the data."
+
+    with pytest.warns(UserWarning) as record:
+        dfs(entityset=es,
+            target_entity='customers',
+            agg_primitives=['count'],
+            where_primitives=['sum', 'count'],
+            max_depth=1,
+            features_only=True)
+
+    assert record[0].message.args[0] == warning_text
+
+
+def test_warns_with_unused_groupby_primitives(pd_es):
+    warning_text = "Some specified primitives were not used during DFS. " + \
+        "groupby_trans_primitives: ['cum_sum']. " + \
+        "This may be caused by a using a value of max_depth that is too small, not setting interesting values, " + \
+        "or it may indicate no compatible variable types for the primitive were found in the data."
+
+    with pytest.warns(UserWarning) as record:
+        dfs(entityset=pd_es,
+            target_entity='sessions',
+            groupby_trans_primitives=['cum_sum'],
+            max_depth=1,
+            features_only=True)
+
+    assert record[0].message.args[0] == warning_text
+
+    # Should not raise a warning
+    with pytest.warns(None) as record:
+        dfs(entityset=pd_es,
+            target_entity='customers',
+            groupby_trans_primitives=['cum_sum'],
+            max_depth=1,
+            features_only=True)
+
+    assert not record
+
+
+def test_warns_with_unused_custom_primitives(pd_es):
+    def above_ten(column):
+        return column > 10
+
+    AboveTen = make_trans_primitive(function=above_ten,
+                                    input_types=[Numeric],
+                                    return_type=Numeric)
+
+    trans_primitives = [AboveTen]
+
+    warning_text = "Some specified primitives were not used during DFS. " + \
+        "trans_primitives: ['above_ten']. " + \
+        "This may be caused by a using a value of max_depth that is too small, not setting interesting values, " + \
+        "or it may indicate no compatible variable types for the primitive were found in the data."
+
+    with pytest.warns(UserWarning) as record:
+        dfs(entityset=pd_es,
+            target_entity='sessions',
+            trans_primitives=trans_primitives,
+            max_depth=1,
+            features_only=True)
+
+    assert record[0].message.args[0] == warning_text
+
+    # Should not raise a warning
+    with pytest.warns(None) as record:
+        dfs(entityset=pd_es,
+            target_entity='customers',
+            trans_primitives=trans_primitives,
+            max_depth=1,
+            features_only=True)
+
+    def max_above_ten(column):
+        return max(column) > 10
+
+    MaxAboveTen = make_agg_primitive(function=max_above_ten,
+                                     input_types=[Numeric],
+                                     return_type=Numeric)
+
+    agg_primitives = [MaxAboveTen]
+
+    warning_text = "Some specified primitives were not used during DFS. " + \
+        "agg_primitives: ['max_above_ten']. " + \
+        "This may be caused by a using a value of max_depth that is too small, not setting interesting values, " + \
+        "or it may indicate no compatible variable types for the primitive were found in the data."
+
+    with pytest.warns(UserWarning) as record:
+        dfs(entityset=pd_es,
+            target_entity='stores',
+            agg_primitives=agg_primitives,
+            max_depth=1,
+            features_only=True)
+
+    assert record[0].message.args[0] == warning_text
+
+    # Should not raise a warning
+    with pytest.warns(None) as record:
+        dfs(entityset=pd_es,
+            target_entity='sessions',
+            agg_primitives=agg_primitives,
+            max_depth=1,
+            features_only=True)
+
+
 def test_calls_progress_callback(entities, relationships):
     class MockProgressCallback:
         def __init__(self):
@@ -372,3 +496,25 @@ def test_calls_progress_callback_cluster(pd_entities, relationships):
 
     assert np.isclose(mock_progress_callback.total_update, 100.0)
     assert np.isclose(mock_progress_callback.total_progress_percent, 100.0)
+
+
+def test_dask_kwargs(pd_entities, relationships):
+    cutoff_times_df = pd.DataFrame({"instance_id": [1, 2, 3],
+                                    "time": [10, 12, 15]})
+    feature_matrix, features = dfs(entities=pd_entities,
+                                   relationships=relationships,
+                                   target_entity="transactions",
+                                   cutoff_time=cutoff_times_df)
+
+    with cluster() as (scheduler, [a, b]):
+        dask_kwargs = {'cluster': scheduler['address']}
+        feature_matrix_2, features_2 = dfs(entities=pd_entities,
+                                           relationships=relationships,
+                                           target_entity="transactions",
+                                           cutoff_time=cutoff_times_df,
+                                           dask_kwargs=dask_kwargs)
+
+    assert all(f1.unique_name() == f2.unique_name() for f1, f2 in zip(features, features_2))
+    for column in feature_matrix:
+        for x, y in zip(feature_matrix[column], feature_matrix_2[column]):
+            assert ((pd.isnull(x) and pd.isnull(y)) or (x == y))

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -323,8 +323,7 @@ def test_warns_with_unused_primitives(es):
             target_entity='customers',
             trans_primitives=trans_primitives,
             agg_primitives=agg_primitives,
-            max_depth=1,
-            features_only=True)
+            max_depth=1)
 
     assert record[0].message.args[0] == warning_text
 
@@ -334,8 +333,7 @@ def test_warns_with_unused_primitives(es):
             target_entity='customers',
             trans_primitives=trans_primitives,
             agg_primitives=agg_primitives,
-            max_depth=2,
-            features_only=True)
+            max_depth=2)
 
     assert not record
 
@@ -351,8 +349,7 @@ def test_warns_with_unused_where_primitives(es):
             target_entity='customers',
             agg_primitives=['count'],
             where_primitives=['sum', 'count'],
-            max_depth=1,
-            features_only=True)
+            max_depth=1)
 
     assert record[0].message.args[0] == warning_text
 
@@ -367,8 +364,7 @@ def test_warns_with_unused_groupby_primitives(pd_es):
         dfs(entityset=pd_es,
             target_entity='sessions',
             groupby_trans_primitives=['cum_sum'],
-            max_depth=1,
-            features_only=True)
+            max_depth=1)
 
     assert record[0].message.args[0] == warning_text
 
@@ -377,8 +373,7 @@ def test_warns_with_unused_groupby_primitives(pd_es):
         dfs(entityset=pd_es,
             target_entity='customers',
             groupby_trans_primitives=['cum_sum'],
-            max_depth=1,
-            features_only=True)
+            max_depth=1)
 
     assert not record
 
@@ -402,8 +397,7 @@ def test_warns_with_unused_custom_primitives(pd_es):
         dfs(entityset=pd_es,
             target_entity='sessions',
             trans_primitives=trans_primitives,
-            max_depth=1,
-            features_only=True)
+            max_depth=1)
 
     assert record[0].message.args[0] == warning_text
 
@@ -412,8 +406,7 @@ def test_warns_with_unused_custom_primitives(pd_es):
         dfs(entityset=pd_es,
             target_entity='customers',
             trans_primitives=trans_primitives,
-            max_depth=1,
-            features_only=True)
+            max_depth=1)
 
     def max_above_ten(column):
         return max(column) > 10
@@ -433,8 +426,7 @@ def test_warns_with_unused_custom_primitives(pd_es):
         dfs(entityset=pd_es,
             target_entity='stores',
             agg_primitives=agg_primitives,
-            max_depth=1,
-            features_only=True)
+            max_depth=1)
 
     assert record[0].message.args[0] == warning_text
 
@@ -443,8 +435,7 @@ def test_warns_with_unused_custom_primitives(pd_es):
         dfs(entityset=pd_es,
             target_entity='sessions',
             agg_primitives=agg_primitives,
-            max_depth=1,
-            features_only=True)
+            max_depth=1)
 
 
 def test_calls_progress_callback(entities, relationships):

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -10,6 +10,7 @@ from featuretools.computational_backends.calculate_feature_matrix import (
     FEATURE_CALCULATION_PERCENTAGE
 )
 from featuretools.entityset import EntitySet, Relationship, Timedelta
+from featuretools.exceptions import UnusedPrimitiveWarning
 from featuretools.primitives import (
     GreaterThanScalar,
     Max,
@@ -319,7 +320,7 @@ def test_warns_with_unused_primitives(es):
         "This may be caused by a using a value of max_depth that is too small, not setting interesting values, " + \
         "or it may indicate no compatible variable types for the primitive were found in the data."
 
-    with pytest.warns(UserWarning) as record:
+    with pytest.warns(UnusedPrimitiveWarning) as record:
         dfs(entityset=es,
             target_entity='customers',
             trans_primitives=trans_primitives,
@@ -357,7 +358,7 @@ def test_warns_with_unused_where_primitives(es):
         "This may be caused by a using a value of max_depth that is too small, not setting interesting values, " + \
         "or it may indicate no compatible variable types for the primitive were found in the data."
 
-    with pytest.warns(UserWarning) as record:
+    with pytest.warns(UnusedPrimitiveWarning) as record:
         dfs(entityset=es,
             target_entity='customers',
             agg_primitives=['count'],
@@ -373,7 +374,7 @@ def test_warns_with_unused_groupby_primitives(pd_es):
         "This may be caused by a using a value of max_depth that is too small, not setting interesting values, " + \
         "or it may indicate no compatible variable types for the primitive were found in the data."
 
-    with pytest.warns(UserWarning) as record:
+    with pytest.warns(UnusedPrimitiveWarning) as record:
         dfs(entityset=pd_es,
             target_entity='sessions',
             groupby_trans_primitives=['cum_sum'],
@@ -406,7 +407,7 @@ def test_warns_with_unused_custom_primitives(pd_es):
         "This may be caused by a using a value of max_depth that is too small, not setting interesting values, " + \
         "or it may indicate no compatible variable types for the primitive were found in the data."
 
-    with pytest.warns(UserWarning) as record:
+    with pytest.warns(UnusedPrimitiveWarning) as record:
         dfs(entityset=pd_es,
             target_entity='sessions',
             trans_primitives=trans_primitives,
@@ -435,7 +436,7 @@ def test_warns_with_unused_custom_primitives(pd_es):
         "This may be caused by a using a value of max_depth that is too small, not setting interesting values, " + \
         "or it may indicate no compatible variable types for the primitive were found in the data."
 
-    with pytest.warns(UserWarning) as record:
+    with pytest.warns(UnusedPrimitiveWarning) as record:
         dfs(entityset=pd_es,
             target_entity='stores',
             agg_primitives=agg_primitives,

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -11,6 +11,7 @@ from featuretools.computational_backends.calculate_feature_matrix import (
 )
 from featuretools.entityset import EntitySet, Relationship, Timedelta
 from featuretools.primitives import (
+    GreaterThanScalar,
     Max,
     Mean,
     Min,
@@ -338,6 +339,18 @@ def test_warns_with_unused_primitives(es):
     assert not record
 
 
+def test_does_not_warn_with_stacking_feature(pd_es):
+    with pytest.warns(None) as record:
+        dfs(entityset=pd_es,
+            target_entity='régions',
+            agg_primitives=['percent_true'],
+            trans_primitives=[GreaterThanScalar(5)],
+            primitive_options={'greater_than_scalar': {'include_entities': ['stores']}},
+            features_only=True)
+
+    assert not record
+
+
 def test_warns_with_unused_where_primitives(es):
     warning_text = "Some specified primitives were not used during DFS:\n" + \
         "  where_primitives: ['count', 'sum']\n" + \
@@ -350,7 +363,7 @@ def test_warns_with_unused_where_primitives(es):
             agg_primitives=['count'],
             where_primitives=['sum', 'count'],
             max_depth=1)
-    breakpoint()
+
     assert record[0].message.args[0] == warning_text
 
 


### PR DESCRIPTION
This PR implements changes that will issue a warning if a user supplies primitives to `dfs` that do not get used in generating the feature matrix. If the default primitives are used, this check is not performed - the check only happens when the user supplies a list of primitives.

Added tests to check for warnings in a variety of situations including trans_primitives, agg_primitives, where_primitives, groupby_trans_primitives and custom primitives.