### PR TITLE
Update dependency action commit message and pr message

### DIFF
--- a/.github/workflows/dependency_check.yml
+++ b/.github/workflows/dependency_check.yml
@@ -23,9 +23,9 @@ jobs:
       uses: Featurelabs/create-pull-request@v2
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        commit-message: Update latest dependencies
-        title: Automated Update with New Dependencies
-        body: "This is an auto-generated PR with dependency updates."
+        commit-message: Update latest_dependencies.txt
+        title: Automated Update to latest_dependencies.txt
+        body: "This is an auto-generated PR with updates to latest_dependencies.txt."
         branch: dep-update
         branch-suffix: short-commit-hash
         base: main

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -18,7 +18,7 @@ Changelog
     * Testing Changes
         * Add fixture for ``ft.demo.load_mock_customer`` (:pr:`1036`)
         * Refactor Dask test units (:pr:`1052`)
-        * Implement automated process for checking critical dependencies (:pr:`1045`, :pr:`1054`)
+        * Implement automated process for checking critical dependencies (:pr:`1045`, :pr:`1054`, :pr:`1081`)
         * Don't run changelog check for release PRs or automated dependency PRs (:pr:`1057`)
         * Fix non-deterministic behavior in Dask test causing codecov issues (:pr:`1070`)
 


### PR DESCRIPTION
Improve the auto generated PR created by the dependency checker action. Update the PR title, PR body and commit message to be more specific with regard to updates being made to `latest_dependencies.txt`.