### PR TITLE
Remove uint8 casting for encode_features boolean columns

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -9,6 +9,7 @@ Changelog
         * Fix issue with missing instance ids and categorical entity index (:pr:`1050`)
         * Remove warnings.simplefilter in feature_set_calculator to un-silence warnings (:pr:`1053`)
         * Fix feature visualization for features with '>' or '<' in name (:pr:`1055`)
+        * Fix boolean dtype mismatch between encode_features and dfs and calculate_feature_matrix (:pr:`1082`)
     * Changes
         * Make DFS match ``TimeSince`` primitive with all ``Datetime`` types (:pr:`1048`)
         * Change default branch to ``main`` (:pr:`1038`)
@@ -24,7 +25,7 @@ Changelog
         * Fix non-deterministic behavior in Dask test causing codecov issues (:pr:`1070`)
 
     Thanks to the following people for contributing to this release:
-    :user:`gsheni`, :user:`systemshift`, :user:`monti-python`, :user:`thehomebrewnerd`, :user:`frances-h`, :user:`rwedge`
+    :user:`gsheni`, :user:`systemshift`, :user:`monti-python`, :user:`thehomebrewnerd`, :user:`frances-h`, :user:`rwedge`, :user:`tamargrey`
 
 **v0.17.0 June 30, 2020**
     * Enhancements

--- a/featuretools/synthesis/encode_features.py
+++ b/featuretools/synthesis/encode_features.py
@@ -137,12 +137,12 @@ def encode_features(feature_matrix, features, top_n=DEFAULT_TOP_N, include_unkno
         for label in unique:
             add = f == label
             encoded.append(add)
-            X[add.get_name()] = (X[f.get_name()] == label).astype("uint8")
+            X[add.get_name()] = (X[f.get_name()] == label)
 
         if include_unknown:
             unknown = f.isin(unique).NOT().rename(f.get_name() + " is unknown")
             encoded.append(unknown)
-            X[unknown.get_name()] = (~X[f.get_name()].isin(unique)).astype("uint8")
+            X[unknown.get_name()] = (~X[f.get_name()].isin(unique))
 
         X.drop(f.get_name(), axis=1, inplace=True)
 

--- a/featuretools/tests/synthesis/test_encode_features.py
+++ b/featuretools/tests/synthesis/test_encode_features.py
@@ -223,4 +223,4 @@ def test_encode_features_matches_calculate_feature_matrix():
     features_calc = calculate_feature_matrix(feature_defs_enc, entityset=pd_es)
 
     assert features_enc['category = e'].dtypes == bool
-    assert features_enc['category = e'].dtypes == features_calc['category = e']
+    assert features_enc['category = e'].dtypes == features_calc['category = e'].dtypes

--- a/featuretools/tests/synthesis/test_encode_features.py
+++ b/featuretools/tests/synthesis/test_encode_features.py
@@ -208,3 +208,19 @@ def test_encode_features_handles_dictionary_input(pd_es):
     assert len(features_encoded) == 8
     for col in true_values:
         assert col in list(feature_matrix_encoded.columns)
+
+
+def test_encode_features_matches_calculate_feature_matrix():
+    df = pd.DataFrame({'category': ['b', 'c', 'd', 'e']})
+
+    pd_es = EntitySet('test')
+    pd_es.entity_from_dataframe(
+        entity_id='a', dataframe=df, index='index', make_index=True)
+    features, feature_defs = dfs(entityset=pd_es, target_entity='a')
+
+    features_enc, feature_defs_enc = encode_features(features, feature_defs, to_encode=['category'])
+
+    features_calc = calculate_feature_matrix(feature_defs_enc, entityset=pd_es)
+
+    assert features_enc['category = e'].dtypes == bool
+    assert features_enc['category = e'].dtypes == features_calc['category = e']


### PR DESCRIPTION
The boolean columns produced by `encode_features` used dtype uint8, while `dfs` and `calculate_feature_matrix` use True/False bools. We're switching `encode_features` to bools as well for consistency. 

-----
*After creating the pull request: in order to pass the **changelog_updated** check you will need to update the "Future Release" section of* `docs/source/changelog.rst` *to include this pull request.*
