### PR TITLE
update primitive options to check reversed inputs if commutative

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,6 +10,7 @@ Changelog
         * Remove warnings.simplefilter in feature_set_calculator to un-silence warnings (:pr:`1053`)
         * Fix feature visualization for features with '>' or '<' in name (:pr:`1055`)
         * Fix boolean dtype mismatch between encode_features and dfs and calculate_feature_matrix (:pr:`1082`)
+        * Update primitive options to check reversed inputs if primitive is commutative (:pr:`1085`)
     * Changes
         * Make DFS match ``TimeSince`` primitive with all ``Datetime`` types (:pr:`1048`)
         * Change default branch to ``main`` (:pr:`1038`)

--- a/featuretools/primitives/options_utils.py
+++ b/featuretools/primitives/options_utils.py
@@ -212,7 +212,7 @@ def filter_groupby_matches_by_options(groupby_matches, options):
                                      groupby=True)
 
 
-def filter_matches_by_options(matches, options, groupby=False):
+def filter_matches_by_options(matches, options, groupby=False, commutative=False):
     # If more than one option, than need to handle each for each input
     if len(options) > 1:
         def is_valid_match(match):
@@ -231,4 +231,6 @@ def filter_matches_by_options(matches, options, groupby=False):
     for match in matches:
         if is_valid_match(match):
             valid_matches.add(match)
+        elif commutative and is_valid_match(tuple(reversed(match))):
+            valid_matches.add(tuple(reversed(match)))
     return valid_matches

--- a/featuretools/primitives/options_utils.py
+++ b/featuretools/primitives/options_utils.py
@@ -1,5 +1,6 @@
 import logging
 import warnings
+from itertools import permutations
 
 from featuretools import primitives
 from featuretools.feature_base import IdentityFeature
@@ -231,6 +232,9 @@ def filter_matches_by_options(matches, options, groupby=False, commutative=False
     for match in matches:
         if is_valid_match(match):
             valid_matches.add(match)
-        elif commutative and is_valid_match(tuple(reversed(match))):
-            valid_matches.add(tuple(reversed(match)))
+        elif commutative:
+            for order in permutations(match):
+                if is_valid_match(order):
+                    valid_matches.add(order)
+                    break
     return valid_matches

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -791,7 +791,9 @@ class DeepFeatureSynthesis(object):
             # features with the same relationship_path.
             matching_inputs = {inputs for inputs in matching_inputs
                                if not _all_direct_and_same_path(inputs)}
-        matching_inputs = filter_matches_by_options(matching_inputs, primitive_options)
+        matching_inputs = filter_matches_by_options(matching_inputs,
+                                                    primitive_options,
+                                                    commutative=primitive.commutative)
         return matching_inputs
 
 

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -1383,8 +1383,7 @@ def test_primitive_options_commutative(es):
                                    primitive_options=options,
                                    max_depth=1)
     features = dfs_obj.build_features()
-    assert any(isinstance(f.primitive, SubtractNumeric) for f in features)
-    for f in features:
-        deps = f.get_dependencies(deep=True)
-        if isinstance(f.primitive, SubtractNumeric):
-            assert 'value_2' == deps[0] and 'value' == deps[1]
+    subtract_numeric = [f for f in features if isinstance(f.primitive, SubtractNumeric)]
+    assert len(subtract_numeric) == 1
+    deps = subtract_numeric[0].get_dependencies(deep=True)
+    assert deps[0].get_name() == 'value_2' and deps[1].get_name() == 'value'

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -1,7 +1,6 @@
 import copy
 
 import dask.dataframe as dd
-import numpy as np
 import pandas as pd
 import pytest
 

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -1378,12 +1378,7 @@ def test_primitive_options_commutative(es):
         input_types = [Numeric, Numeric, Numeric]
         return_type = Numeric
         dask_compatible = True
-
-        def __init__(self, commutative=True):
-            self.commutative = commutative
-
-        def get_function(self):
-            return np.add
+        commutative = True
 
         def generate_name(self, base_feature_names):
             return "%s + %s + %s" % (base_feature_names[0], base_feature_names[1], base_feature_names[2])


### PR DESCRIPTION
Updates primitive option matching to also check reversed inputs if primitive is commutative. Only checks reverse if first ordering fails to prevent double features from being created. 

Fixes #1075 
