### PR TITLE
Sort matching_inputs to get consistent ordering

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -12,6 +12,7 @@ Changelog
         * Fix feature visualization for features with '>' or '<' in name (:pr:`1055`)
         * Fix boolean dtype mismatch between encode_features and dfs and calculate_feature_matrix (:pr:`1082`)
         * Update primitive options to check reversed inputs if primitive is commutative (:pr:`1085`)
+        * Fix inconsistent ordering of features between kernel restarts (:pr:`1088`)
     * Changes
         * Make DFS match ``TimeSince`` primitive with all ``Datetime`` types (:pr:`1048`)
         * Change default branch to ``main`` (:pr:`1038`)

--- a/featuretools/primitives/options_utils.py
+++ b/featuretools/primitives/options_utils.py
@@ -237,4 +237,4 @@ def filter_matches_by_options(matches, options, groupby=False, commutative=False
                 if is_valid_match(order):
                     valid_matches.add(order)
                     break
-    return valid_matches
+    return sorted(list(valid_matches), key=lambda features: ([feature.unique_name() for feature in features]))

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -794,7 +794,7 @@ class DeepFeatureSynthesis(object):
         matching_inputs = filter_matches_by_options(matching_inputs,
                                                     primitive_options,
                                                     commutative=primitive.commutative)
-        return matching_inputs
+        return sorted(list(matching_inputs), key=lambda features: ([feature.get_name() for feature in features]))
 
 
 def check_stacking(primitive, inputs):

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -794,7 +794,6 @@ class DeepFeatureSynthesis(object):
         matching_inputs = filter_matches_by_options(matching_inputs,
                                                     primitive_options,
                                                     commutative=primitive.commutative)
-
         return matching_inputs
 
 

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -794,7 +794,8 @@ class DeepFeatureSynthesis(object):
         matching_inputs = filter_matches_by_options(matching_inputs,
                                                     primitive_options,
                                                     commutative=primitive.commutative)
-        return sorted(list(matching_inputs), key=lambda features: ([feature.get_name() for feature in features]))
+
+        return matching_inputs
 
 
 def check_stacking(primitive, inputs):

--- a/featuretools/tests/primitive_tests/test_dask_primitives.py
+++ b/featuretools/tests/primitive_tests/test_dask_primitives.py
@@ -1,5 +1,3 @@
-import random
-
 import pandas as pd
 
 import featuretools as ft
@@ -21,7 +19,6 @@ def test_transform(pd_es, dask_es):
 
     assert pd_es == dask_es
 
-    # TODO: Update when issue #833 is closed to use max_features instead of random sampling
     # Run DFS using each entity as a target and confirm results match
     for entity in pd_es.entities:
         features = ft.dfs(entityset=pd_es,
@@ -39,13 +36,10 @@ def test_transform(pd_es, dask_es):
                                features_only=True)
         assert features == dask_features
 
-        # Randomly sample up to 100 features to use to calculate feature matrix values to confirm
-        # output is the same between dask and pandas. Use random seed to make sure same features
-        # are tested each time. Not testing on all returned features due to long run times.
-        random.seed(0)
-        features = random.sample(features, min(100, len(features)))
-        fm = ft.calculate_feature_matrix(features=features, entityset=pd_es, cutoff_time=cutoff_time)
-        dask_fm = ft.calculate_feature_matrix(features=features, entityset=dask_es, cutoff_time=cutoff_time)
+        # Calculate feature matrix values to confirm output is the same between dask and pandas.
+        # Not testing on all returned features due to long run times.
+        fm = ft.calculate_feature_matrix(features=features[:100], entityset=pd_es, cutoff_time=cutoff_time)
+        dask_fm = ft.calculate_feature_matrix(features=dask_features[:100], entityset=dask_es, cutoff_time=cutoff_time)
 
         # Use the same columns and make sure both indexes are sorted the same
         dask_computed_fm = dask_fm.compute().set_index(entity.index).loc[fm.index][fm.columns]

--- a/featuretools/tests/primitive_tests/test_feature_serialization.py
+++ b/featuretools/tests/primitive_tests/test_feature_serialization.py
@@ -238,15 +238,12 @@ def test_deserialize_features_s3(pd_es, url, profile_name):
     trans_primitives = [Day, Year, Month, Weekday, Haversine, NumWords,
                         NumCharacters]
 
-    features_original = sorted(ft.dfs(target_entity='sessions',
-                                      entityset=pd_es,
-                                      features_only=True,
-                                      agg_primitives=agg_primitives,
-                                      trans_primitives=trans_primitives),
-                               key=lambda x: x.unique_name())
-    features_deserialized = sorted(ft.load_features(url,
-                                                    profile_name=profile_name),
-                                   key=lambda x: x.unique_name())
+    features_original = ft.dfs(target_entity='sessions',
+                               entityset=pd_es,
+                               features_only=True,
+                               agg_primitives=agg_primitives,
+                               trans_primitives=trans_primitives)
+    features_deserialized = ft.load_features(url, profile_name=profile_name)
     assert_features(features_original, features_deserialized)
 
 


### PR DESCRIPTION
### Pull Request Description
Using sets for `matching_inputs` means that with different kernel restarts, we could get different orders of features. By sorting a list of the `matching_inputs` before creating the features, we get consistent results.
