### PR TITLE
Restrict pandas to <1.1.0

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -14,6 +14,7 @@ Changelog
         * Make DFS match ``TimeSince`` primitive with all ``Datetime`` types (:pr:`1048`)
         * Change default branch to ``main`` (:pr:`1038`)
         * Raise TypeError if improper input is supplied to ``Entity.delete_variables()`` (:pr:`1064`)
+        * Restrict pandas version to <1.1.0 due to issues with Dask EntitySets (:pr:`1089`)
     * Documentation Changes
         * Remove benchmarks folder (:pr:`1049`)
         * Add custom variables types section to variables page (:pr:`1066`)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 scipy>=0.13.3
 numpy>=1.13.3
-pandas>=0.24.1
+pandas>=0.24.1,<1.1.0
 tqdm>=4.32.0
 pyyaml>=3.12
 cloudpickle>=0.4.0


### PR DESCRIPTION
Due to issues discovered using Dask Entitysets with pandas 1.1.0 installed, the pandas version is being restricted to <1.1.0 until the issue is resolved.