### PR TITLE
Change setup.py to load nlp_primitives[complete]

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,7 +7,7 @@ Changelog
     * Fixes
         * Fix ``EntitySet.plot()`` when given a dask entityset (:pr:`1086`)
     * Changes
-        * Use ``nlp-primitives[complete]`` install for ``nlp_primivies`` extra in ``setup.py`` (:pr:`1103`)
+        * Use ``nlp-primitives[complete]`` install for ``nlp_primitives`` extra in ``setup.py`` (:pr:`1103`)
     * Documentation Changes
     * Testing Changes
         * Use CircleCI matrix jobs in config to trigger multiple runs of same job with different parameters (:pr:`1105`)

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -7,12 +7,13 @@ Changelog
     * Fixes
         * Fix ``EntitySet.plot()`` when given a dask entityset (:pr:`1086`)
     * Changes
+        * Use ``nlp-primitives[complete]`` install for ``nlp_primivies`` extra in ``setup.py`` (:pr:`1103`)
     * Documentation Changes
     * Testing Changes
         * Use CircleCI matrix jobs in config to trigger multiple runs of same job with different parameters (:pr:`1105`)
 
     Thanks to the following people for contributing to this release:
-    :user:`systemshift`, :user:`gsheni`,
+    :user:`systemshift`, :user:`gsheni`, :user:`thehomebrewnerd`
 
 **v0.18.0 July 31, 2020**
     * Enhancements

--- a/featuretools/tests/latest_dependencies.txt
+++ b/featuretools/tests/latest_dependencies.txt
@@ -6,4 +6,4 @@ numpy==1.19.1
 pandas==1.1.0
 psutil==5.7.2
 scipy==1.5.2
-tqdm==4.48.1
+tqdm==4.48.2

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ extras_require = {
   'tsfresh': ['featuretools-tsfresh-primitives >= 0.1.0'],
   'update_checker': ['featuretools-update-checker >= 1.0.0'],
   'categorical_encoding': ['categorical-encoding >= 0.2.0'],
-  'nlp_primitives': ['nlp_primitives[complete] >= 1.0.0'],
+  'nlp_primitives': ['nlp-primitives[complete] >= 1.0.0'],
   'autonormalize': ['autonormalize >= 1.0.0'],
   'sklearn_transformer': ['featuretools-sklearn-transformer >= 0.1.0'],
 }

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ extras_require = {
   'tsfresh': ['featuretools-tsfresh-primitives >= 0.1.0'],
   'update_checker': ['featuretools-update-checker >= 1.0.0'],
   'categorical_encoding': ['categorical-encoding >= 0.2.0'],
-  'nlp_primitives': ['nlp-primitives >= 0.2.2'],
+  'nlp_primitives': ['nlp_primitives[complete] @ git+https://github.com/FeatureLabs/nlp_primitives.git@nlp-complete'],
   'autonormalize': ['autonormalize >= 1.0.0'],
   'sklearn_transformer': ['featuretools-sklearn-transformer >= 0.1.0'],
 }

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ extras_require = {
   'tsfresh': ['featuretools-tsfresh-primitives >= 0.1.0'],
   'update_checker': ['featuretools-update-checker >= 1.0.0'],
   'categorical_encoding': ['categorical-encoding >= 0.2.0'],
-  'nlp_primitives': ['nlp_primitives[complete] @ git+https://github.com/FeatureLabs/nlp_primitives.git@nlp-complete'],
+  'nlp_primitives': ['nlp_primitives[complete] >= 1.0.0'],
   'autonormalize': ['autonormalize >= 1.0.0'],
   'sklearn_transformer': ['featuretools-sklearn-transformer >= 0.1.0'],
 }


### PR DESCRIPTION
The NLP Primitives repo is being updated so that running `pip install nlp_primitives` will no longer install tensorflow, and thus the primitives that depend on tensorflow won't work with this install. In order to install tensorflow with nlp_primitives after the next version is released, nlp primitives will need to be installed with `pip install nlp_primitives[complete]`.

This PR updates featuretools `setup.py` to install `nlp_primitives[complete]` when a user installs featuretools with the nlp primitives extra: `pip install featuretools[nlp_primitives]` so that all nlp primitives will be available in featuretools.