### PR TITLE
[Koalas] Make Koalas optional dependency 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
           python -m pip install --upgrade pip
       - when:
           condition: 
-            equal: [ "complete", << parameters.optional_libraries >> ]
+            equal: [ "optional", << parameters.optional_libraries >> ]
           steps:
             - run: |
                 source venv/bin/activate
@@ -108,7 +108,7 @@ jobs:
                 python -m pip install -r unpacked_sdist/test-requirements.txt
       - unless:
           condition:
-            equal: ["complete", << parameters.optional_libraries >> ]
+            equal: ["optional", << parameters.optional_libraries >> ]
           steps:
             - run: |
                 source venv/bin/activate
@@ -149,7 +149,7 @@ jobs:
       - run: sudo apt update && sudo apt install -y graphviz
       - when:
           condition:
-            equal: ["complete", << parameters.optional_libraries >>]
+            equal: ["optional", << parameters.optional_libraries >>]
           steps:
             - run: |
                 sudo apt install -y openjdk-11-jre-headless
@@ -161,7 +161,7 @@ jobs:
           condition:
             and:
               - equal: [ "3.6", << parameters.image_tag >> ]
-              - equal: ["complete", << parameters.optional_libraries >>]
+              - equal: ["optional", << parameters.optional_libraries >>]
           steps:
             - run: |
                 source venv/bin/activate
@@ -177,7 +177,7 @@ jobs:
           condition:
             and: 
               - equal: [ "3.6", << parameters.image_tag >> ]
-              - equal: ["complete", << parameters.optional_libraries >>]
+              - equal: ["optional", << parameters.optional_libraries >>]
           steps:
             - run: |
                 source venv/bin/activate
@@ -271,13 +271,13 @@ workflows:
           matrix:
             parameters:
               image_tag: ["3.8", "3.7", "3.6"]
-              optional_libraries: ["minimal", "complete"]
+              optional_libraries: ["minimal", "optional"]
           name: << matrix.image_tag >> install featuretools << matrix.optional_libraries >>
       - unit_tests:
           matrix:
             parameters:
               image_tag: ["3.8", "3.7", "3.6"]
-              optional_libraries: ["minimal", "complete"]
+              optional_libraries: ["minimal", "optional"]
           name: << matrix.image_tag >> unit tests << matrix.optional_libraries >>
           requires:
             - << matrix.image_tag >> install featuretools << matrix.optional_libraries >>
@@ -287,14 +287,14 @@ workflows:
               image_tag: ["3.8", "3.7", "3.6"]
           name: << matrix.image_tag >> lint test
           requires:
-            - << matrix.image_tag >> install featuretools complete
+            - << matrix.image_tag >> install featuretools optional
       - build_docs:
           matrix:
             parameters:
               image_tag: ["3.8", "3.7", "3.6"]
           name: build docs << matrix.image_tag >>
           requires:
-            - << matrix.image_tag >> install featuretools complete
+            - << matrix.image_tag >> install featuretools optional
       - install_ft_complete:
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,8 @@ jobs:
     parameters:
       image_tag:
         type: string
+      optional_libraries:
+        type: string
     executor:
       name: python
       image_tag: << parameters.image_tag >>
@@ -96,8 +98,17 @@ jobs:
           source venv/bin/activate
           python -m pip config --site set global.progress_bar off
           python -m pip install --upgrade pip
-          python -m pip install -e unpacked_sdist/
-          python -m pip install -r unpacked_sdist/test-requirements.txt
+      - when:
+          condition: 
+            equal: [ "complete", << parameters.optional_libraries >> ]
+          steps:
+            - run: python -m pip install -e unpacked_sdist/[koalas]
+      - unless:
+          condition:
+            equal: ["complete", << parameters.optional_libraries >> ]
+          steps:
+            - run: python -m pip install -e unpacked_sdist/
+      - run: python -m pip install -r unpacked_sdist/test-requirements.txt
       - persist_to_workspace:
           root: ~/featuretools
           paths:
@@ -124,6 +135,8 @@ jobs:
     parameters:
       image_tag:
         type: string
+      optional_libraries:
+        type: string
     executor:
       name: python
       image_tag: << parameters.image_tag >>
@@ -135,7 +148,9 @@ jobs:
           at: ~/featuretools
       - when:
           condition:
-            equal: [ "3.6", << parameters.image_tag >> ]
+            and:
+              - equal: [ "3.6", << parameters.image_tag >> ]
+              - equal: ["complete", << parameters.optional_libraries >>]
           steps:
             - run: |
                 source venv/bin/activate
@@ -149,7 +164,9 @@ jobs:
                 codecov --required
       - unless:
           condition:
-            equal: [ "3.6", << parameters.image_tag >> ]
+            and: 
+              - equal: [ "3.6", << parameters.image_tag >> ]
+              - equal: ["complete", << parameters.optional_libraries >>]
           steps:
             - run: |
                 source venv/bin/activate
@@ -243,28 +260,30 @@ workflows:
           matrix:
             parameters:
               image_tag: ["3.8", "3.7", "3.6"]
-          name: << matrix.image_tag >> install featuretools
+              optional_libraries: ["minimal", "complete"]
+          name: << matrix.image_tag >> install featuretools << matrix.optional_libraries >>
       - unit_tests:
           matrix:
             parameters:
               image_tag: ["3.8", "3.7", "3.6"]
-          name: << matrix.image_tag >> unit tests
+              optional_libraries: ["minimal", "complete"]
+          name: << matrix.image_tag >> unit tests << matrix.optional_libraries >>
           requires:
-            - << matrix.image_tag >> install featuretools
+            - << matrix.image_tag >> install featuretools << matrix.optional_libraries >>
       - lint_test:
           matrix:
             parameters:
               image_tag: ["3.8", "3.7", "3.6"]
           name: << matrix.image_tag >> lint test
           requires:
-            - << matrix.image_tag >> install featuretools
+            - << matrix.image_tag >> install featuretools complete
       - build_docs:
           matrix:
             parameters:
               image_tag: ["3.8", "3.7", "3.6"]
           name: build docs << matrix.image_tag >>
           requires:
-            - << matrix.image_tag >> install featuretools
+            - << matrix.image_tag >> install featuretools complete
       - install_ft_complete:
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,13 +102,16 @@ jobs:
           condition: 
             equal: [ "complete", << parameters.optional_libraries >> ]
           steps:
-            - run: python -m pip install -e unpacked_sdist/[koalas]
+            - run: |
+                python -m pip install -e unpacked_sdist/[koalas]
+                python -m pip install -r unpacked_sdist/test-requirements.txt
       - unless:
           condition:
             equal: ["complete", << parameters.optional_libraries >> ]
           steps:
-            - run: python -m pip install -e unpacked_sdist/
-      - run: python -m pip install -r unpacked_sdist/test-requirements.txt
+            - run: |
+                python -m pip install -e unpacked_sdist/
+                python -m pip install -r unpacked_sdist/test-requirements.txt
       - persist_to_workspace:
           root: ~/featuretools
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,6 +103,7 @@ jobs:
             equal: [ "complete", << parameters.optional_libraries >> ]
           steps:
             - run: |
+                source venv/bin/activate
                 python -m pip install -e unpacked_sdist/[koalas]
                 python -m pip install -r unpacked_sdist/test-requirements.txt
       - unless:
@@ -110,6 +111,7 @@ jobs:
             equal: ["complete", << parameters.optional_libraries >> ]
           steps:
             - run: |
+                source venv/bin/activate
                 python -m pip install -e unpacked_sdist/
                 python -m pip install -r unpacked_sdist/test-requirements.txt
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,8 +146,14 @@ jobs:
       name: python
       image_tag: << parameters.image_tag >>
     steps:
-      - run: sudo apt update && sudo apt install -y graphviz openjdk-11-jre-headless
-      - run: JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
+      - run: sudo apt update && sudo apt install -y graphviz
+      - when:
+          condition:
+            equal: ["complete", << parameters.optional_libraries >>]
+          steps:
+            - run: |
+                sudo apt install -y openjdk-11-jre-headless
+                JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
       - checkout
       - attach_workspace:
           at: ~/featuretools

--- a/featuretools/computational_backends/calculate_feature_matrix.py
+++ b/featuretools/computational_backends/calculate_feature_matrix.py
@@ -8,7 +8,6 @@ from datetime import datetime
 
 import cloudpickle
 import dask.dataframe as dd
-import databricks.koalas as ks
 import numpy as np
 import pandas as pd
 
@@ -28,8 +27,14 @@ from featuretools.computational_backends.utils import (
 from featuretools.entityset.relationship import RelationshipPath
 from featuretools.feature_base import AggregationFeature, FeatureBase
 from featuretools.utils import Trie
-from featuretools.utils.gen_utils import make_tqdm_iterator
+from featuretools.utils.gen_utils import (
+    import_or_none,
+    is_instance,
+    make_tqdm_iterator
+)
 from featuretools.variable_types import NumericTimeIndex
+
+ks = import_or_none('databricks.koalas')
 
 logger = logging.getLogger('featuretools.computational_backend')
 
@@ -177,7 +182,7 @@ def calculate_feature_matrix(features, entityset=None, cutoff_time=None, instanc
 
         if isinstance(instance_ids, dd.Series):
             instance_ids = instance_ids.compute()
-        if isinstance(instance_ids, ks.Series):
+        if is_instance(instance_ids, ks, 'Series'):
             instance_ids = instance_ids.to_pandas()
 
         # convert list or range object into series
@@ -421,7 +426,7 @@ def calculate_chunk(cutoff_time, chunk_size, feature_set, entityset, approximate
                                                training_window=window,
                                                include_cutoff_time=include_cutoff_time)
 
-                if isinstance(_feature_matrix, (dd.DataFrame, ks.DataFrame)):
+                if is_instance(_feature_matrix, (dd, ks), 'DataFrame'):
                     id_name = _feature_matrix.columns[-1]
                 else:
                     id_name = _feature_matrix.index.name
@@ -458,7 +463,7 @@ def calculate_chunk(cutoff_time, chunk_size, feature_set, entityset, approximate
                             pass_df = dd.from_pandas(pass_through[[id_name, 'time', col]], npartitions=_feature_matrix.npartitions)
                             _feature_matrix = _feature_matrix.merge(pass_df, how="outer")
                         _feature_matrix = _feature_matrix.drop(columns=['time'])
-                    elif isinstance(_feature_matrix, ks.DataFrame) and (len(pass_columns) > 0):
+                    elif is_instance(_feature_matrix, ks, 'DataFrame') and (len(pass_columns) > 0):
                         _feature_matrix['time'] = time_last
                         for col in pass_columns:
                             pass_df = ks.from_pandas(pass_through[[id_name, 'time', col]])
@@ -468,7 +473,7 @@ def calculate_chunk(cutoff_time, chunk_size, feature_set, entityset, approximate
 
     if any(isinstance(fm, dd.DataFrame) for fm in feature_matrix):
         feature_matrix = dd.concat(feature_matrix)
-    elif any(isinstance(fm, ks.DataFrame) for fm in feature_matrix):
+    elif any(is_instance(fm, ks, 'DataFrame') for fm in feature_matrix):
         feature_matrix = ks.concat(feature_matrix)
     else:
         feature_matrix = pd.concat(feature_matrix)

--- a/featuretools/entityset/deserialize.py
+++ b/featuretools/entityset/deserialize.py
@@ -132,7 +132,9 @@ def read_entity_data(description, path):
     if entity_type == 'dask':
         lib = dd
     elif entity_type == 'koalas':
-        lib = import_or_raise('databricks.koalas', 'Koalas not found, cannot serialize Koalas entityset')
+        import_error = 'Cannot load Koalas entityset - unable to import Koalas. ' \
+                       'Consider doing a pip install with [koalas] extra to install Koalas with pip'
+        lib = import_or_raise('databricks.koalas', import_error)
         read_kwargs['multiline'] = True
         kwargs['compression'] = str(kwargs['compression'])
     else:

--- a/featuretools/entityset/deserialize.py
+++ b/featuretools/entityset/deserialize.py
@@ -4,14 +4,13 @@ import tarfile
 import tempfile
 from pathlib import Path
 
+import dask.dataframe as dd
 import numpy as np
 import pandas as pd
-from dask import dataframe as dd
-from databricks import koalas as ks
 
 from featuretools.entityset.relationship import Relationship
 from featuretools.entityset.serialize import FORMATS
-from featuretools.utils.gen_utils import check_schema_version
+from featuretools.utils.gen_utils import check_schema_version, import_or_raise
 from featuretools.utils.s3_utils import get_transport_params, use_smartopen_es
 from featuretools.utils.wrangle import _is_s3, _is_url
 from featuretools.variable_types import LatLong, find_variable_types
@@ -133,7 +132,7 @@ def read_entity_data(description, path):
     if entity_type == 'dask':
         lib = dd
     elif entity_type == 'koalas':
-        lib = ks
+        lib = import_or_raise('databricks.koalas', 'Koalas not found, cannot serialize Koalas entityset')
         read_kwargs['multiline'] = True
         kwargs['compression'] = str(kwargs['compression'])
     else:

--- a/featuretools/entityset/deserialize.py
+++ b/featuretools/entityset/deserialize.py
@@ -133,7 +133,7 @@ def read_entity_data(description, path):
         lib = dd
     elif entity_type == 'koalas':
         import_error = 'Cannot load Koalas entityset - unable to import Koalas. ' \
-                       'Consider doing a pip install with [koalas] extra to install Koalas with pip'
+                       'Consider doing a pip install with featuretools[koalas] to install Koalas with pip'
         lib = import_or_raise('databricks.koalas', import_error)
         read_kwargs['multiline'] = True
         kwargs['compression'] = str(kwargs['compression'])

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -2,7 +2,6 @@ import logging
 import warnings
 
 import dask.dataframe as dd
-import databricks.koalas as ks
 import numpy as np
 import pandas as pd
 import pandas.api.types as pdtypes
@@ -15,12 +14,15 @@ from featuretools.utils.entity_utils import (
     get_linked_vars,
     infer_variable_types
 )
+from featuretools.utils.gen_utils import import_or_none, is_instance
 from featuretools.utils.wrangle import (
     _check_time_type,
     _check_timedelta,
     _dataframes_equal
 )
 from featuretools.variable_types import find_variable_types
+
+ks = import_or_none('databricks.koalas')
 
 logger = logging.getLogger('featuretools.entityset')
 
@@ -250,7 +252,7 @@ class Entity(object):
             df = self.df.head(0)
 
         else:
-            if isinstance(instance_vals, dd.Series) or isinstance(instance_vals, ks.Series):
+            if is_instance(instance_vals, (dd, ks), 'Series'):
                 df = self.df.merge(instance_vals.to_frame(), how="inner", on=variable_id)
             else:
                 df = self.df[self.df[variable_id].isin(instance_vals)]
@@ -451,7 +453,7 @@ class Entity(object):
                             " other entityset time indexes" %
                             (self.id, time_type))
 
-        if isinstance(self.df, (dd.DataFrame, ks.DataFrame)):
+        if is_instance(self.df, (dd, ks), 'DataFrame'):
             t = time_type  # skip checking values
             already_sorted = True  # skip sorting
         else:
@@ -486,7 +488,7 @@ class Entity(object):
 
     def set_secondary_time_index(self, secondary_time_index):
         for time_index, columns in secondary_time_index.items():
-            if isinstance(self.df, (dd.DataFrame, ks.DataFrame)) or self.df.empty:
+            if is_instance(self.df, (dd, ks), 'DataFrame') or self.df.empty:
                 time_to_check = vtypes.DEFAULT_DTYPE_VALUES[self[time_index]._default_pandas_dtype]
             else:
                 time_to_check = self.df[time_index].head(1).iloc[0]
@@ -516,9 +518,9 @@ class Entity(object):
             instance_vals = [instance_vals]
 
         # convert iterable to pd.Series
-        if type(instance_vals) == pd.DataFrame:
+        if isinstance(instance_vals, pd.DataFrame):
             out_vals = instance_vals[variable_id]
-        elif type(instance_vals) == pd.Series or type(instance_vals) == dd.Series or type(instance_vals) == ks.Series:
+        elif is_instance(instance_vals, (pd, dd, ks), 'Series'):
             out_vals = instance_vals.rename(variable_id)
         else:
             out_vals = pd.Series(instance_vals)
@@ -537,7 +539,7 @@ class Entity(object):
         If this entity does not have a time index, return the original
         dataframe.
         """
-        if isinstance(df, ks.DataFrame) and isinstance(time_last, np.datetime64):
+        if is_instance(df, ks, 'DataFrame') and isinstance(time_last, np.datetime64):
             time_last = pd.to_datetime(time_last)
         if self.time_index:
             df_empty = df.empty if isinstance(df, pd.DataFrame) else False
@@ -575,7 +577,7 @@ class Entity(object):
                 if isinstance(df, dd.DataFrame):
                     for col in columns:
                         df[col] = df[col].mask(mask, np.nan)
-                elif isinstance(df, ks.DataFrame):
+                elif is_instance(df, ks, 'DataFrame'):
                     df.loc[mask, columns] = None
                 else:
                     df.loc[mask, columns] = np.nan
@@ -608,7 +610,7 @@ def _create_index(index, make_index, df):
         if isinstance(df, dd.DataFrame):
             df[index] = 1
             df[index] = df[index].cumsum() - 1
-        elif isinstance(df, ks.DataFrame):
+        elif is_instance(df, ks, 'DataFrame'):
             df = df.koalas.attach_id_column('distributed-sequence', index)
         else:
             df.insert(0, index, range(len(df)))

--- a/featuretools/entityset/serialize.py
+++ b/featuretools/entityset/serialize.py
@@ -5,10 +5,12 @@ import tarfile
 import tempfile
 
 import dask.dataframe as dd
-import databricks.koalas as ks
 
+from featuretools.utils.gen_utils import import_or_none, is_instance
 from featuretools.utils.s3_utils import get_transport_params, use_smartopen_es
 from featuretools.utils.wrangle import _is_s3, _is_url
+
+ks = import_or_none('databricks.koalas')
 
 FORMATS = ['csv', 'pickle', 'parquet']
 SCHEMA_VERSION = "4.0.0"
@@ -24,11 +26,11 @@ def entity_to_description(entity):
         dictionary (dict) : Description of :class:`.Entity`.
     '''
     index = entity.df.columns.isin([variable.id for variable in entity.variables])
-    indexer = entity.df.columns[index].to_list() if isinstance(entity.df, ks.DataFrame) else entity.df.columns[index]
+    indexer = entity.df.columns[index].to_list() if is_instance(entity.df, ks, 'DataFrame') else entity.df.columns[index]
     dtypes = entity.df[indexer].dtypes.astype(str).to_dict()
     if isinstance(entity.df, dd.DataFrame):
         entity_type = 'dask'
-    elif isinstance(entity.df, ks.DataFrame):
+    elif is_instance(entity.df, ks, 'DataFrame'):
         entity_type = 'koalas'
     else:
         entity_type = 'pandas'

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -2,7 +2,6 @@ import logging
 from collections import defaultdict
 
 from dask import dataframe as dd
-from databricks import koalas as ks
 
 from featuretools import primitives, variable_types
 from featuretools.entityset.relationship import RelationshipPath
@@ -24,7 +23,10 @@ from featuretools.primitives.options_utils import (
     generate_all_primitive_options,
     ignore_entity_for_primitive
 )
+from featuretools.utils.gen_utils import import_or_none, is_instance
 from featuretools.variable_types import Boolean, Discrete, Id, Numeric
+
+ks = import_or_none('databricks.koalas')
 
 logger = logging.getLogger('featuretools')
 
@@ -183,7 +185,7 @@ class DeepFeatureSynthesis(object):
             agg_primitives = primitives.get_default_aggregation_primitives()
             if any(isinstance(e.df, dd.DataFrame) for e in self.es.entities):
                 agg_primitives = [p for p in agg_primitives if p.dask_compatible]
-            if any(isinstance(e.df, ks.DataFrame) for e in self.es.entities):
+            if any(is_instance(e.df, ks, 'DataFrame') for e in self.es.entities):
                 agg_primitives = [p for p in agg_primitives if p.koalas_compatible]
         self.agg_primitives = []
         agg_prim_dict = primitives.get_aggregation_primitives()
@@ -204,7 +206,7 @@ class DeepFeatureSynthesis(object):
             trans_primitives = primitives.get_default_transform_primitives()
             if any(isinstance(e.df, dd.DataFrame) for e in self.es.entities):
                 trans_primitives = [p for p in trans_primitives if p.dask_compatible]
-            if any(isinstance(e.df, ks.DataFrame) for e in self.es.entities):
+            if any(is_instance(e.df, ks, 'DataFrame') for e in self.es.entities):
                 trans_primitives = [p for p in trans_primitives if p.koalas_compatible]
         self.trans_primitives = []
         for t in trans_primitives:
@@ -240,7 +242,7 @@ class DeepFeatureSynthesis(object):
             if not all([primitive.dask_compatible for primitive in all_primitives]):
                 bad_primitives = ", ".join([prim.name for prim in all_primitives if not prim.dask_compatible])
                 raise ValueError('Selected primitives are incompatible with Dask EntitySets: {}'.format(bad_primitives))
-        if any(isinstance(entity.df, ks.DataFrame) for entity in self.es.entities):
+        if any(is_instance(entity.df, ks, 'DataFrame') for entity in self.es.entities):
             if not all([primitive.koalas_compatible for primitive in all_primitives]):
                 bad_primitives = ", ".join([prim.name for prim in all_primitives if not prim.dask_compatible])
                 raise ValueError('Selected primitives are incompatible with Koalas EntitySets: {}'.format(bad_primitives))

--- a/featuretools/tests/computational_backend/test_feature_set_calculator.py
+++ b/featuretools/tests/computational_backend/test_feature_set_calculator.py
@@ -38,10 +38,7 @@ from featuretools.primitives import (  # NMostCommon,
 from featuretools.primitives.base import AggregationPrimitive
 from featuretools.tests.testing_utils import backward_path, to_pandas
 from featuretools.utils import Trie
-from featuretools.utils.gen_utils import import_or_none
 from featuretools.variable_types import Numeric
-
-ks = import_or_none('databricks.koalas')
 
 
 def test_make_identity(es):
@@ -441,10 +438,9 @@ def dd_df(pd_df):
 
 @pytest.fixture
 def ks_df(pd_df):
+    ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
-    if not ks:
-        pytest.skip('Koalas not installed, skipping')
     return ks.from_pandas(pd_df)
 
 
@@ -752,10 +748,9 @@ def dd_parent_child(pd_parent_child):
 
 @pytest.fixture
 def ks_parent_child(pd_parent_child):
+    ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
-    if not ks:
-        pytest.skip('Koalas not installed, skipping')
     parent_df, child_df = pd_parent_child
     parent_df = ks.from_pandas(parent_df)
     child_df = ks.from_pandas(child_df)

--- a/featuretools/tests/computational_backend/test_feature_set_calculator.py
+++ b/featuretools/tests/computational_backend/test_feature_set_calculator.py
@@ -38,8 +38,8 @@ from featuretools.primitives import (  # NMostCommon,
 from featuretools.primitives.base import AggregationPrimitive
 from featuretools.tests.testing_utils import backward_path, to_pandas
 from featuretools.utils import Trie
-from featuretools.variable_types import Numeric
 from featuretools.utils.gen_utils import import_or_none
+from featuretools.variable_types import Numeric
 
 ks = import_or_none('databricks.koalas')
 

--- a/featuretools/tests/conftest.py
+++ b/featuretools/tests/conftest.py
@@ -8,8 +8,8 @@ import pytest
 
 import featuretools as ft
 from featuretools.tests.testing_utils import make_ecommerce_entityset
-from featuretools.utils.koalas_utils import pd_to_ks_clean
 from featuretools.utils.gen_utils import import_or_none
+from featuretools.utils.koalas_utils import pd_to_ks_clean
 
 ks = import_or_none('databricks.koalas')
 SparkSession = import_or_none('pyspark.sql.SparkSession')

--- a/featuretools/tests/conftest.py
+++ b/featuretools/tests/conftest.py
@@ -11,16 +11,13 @@ from featuretools.tests.testing_utils import make_ecommerce_entityset
 from featuretools.utils.gen_utils import import_or_none
 from featuretools.utils.koalas_utils import pd_to_ks_clean
 
-ks = import_or_none('databricks.koalas')
-sql = import_or_none('pyspark.sql')
-
 
 @pytest.fixture(scope='session', autouse=True)
 def spark_session():
+    sql = import_or_none('pyspark.sql')
     if not sql:
         return
-    SparkSession = sql.SparkSession
-    spark = SparkSession.builder \
+    spark = sql.SparkSession.builder \
         .master('local[2]') \
         .config("spark.driver.extraJavaOptions", "-Dio.netty.tryReflectionSetAccessible=True") \
         .config("spark.sql.shuffle.partitions", "2") \
@@ -60,10 +57,9 @@ def dask_es(make_es):
 
 @pytest.fixture
 def ks_es(make_es):
+    ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
-    if not ks:
-        pytest.skip('Koalas not installed, skipping Koalas tests')
     ks_es = copy.deepcopy(make_es)
     for entity in ks_es.entities:
         cleaned_df = pd_to_ks_clean(entity.df).reset_index(drop=True)
@@ -144,10 +140,9 @@ def dask_diamond_es(pd_diamond_es):
 
 @pytest.fixture
 def ks_diamond_es(pd_diamond_es):
+    ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
-    if not ks:
-        pytest.skip('Koalas not installed, skipping')
     entities = {}
     for entity in pd_diamond_es.entities:
         entities[entity.id] = (ks.from_pandas(pd_to_ks_clean(entity.df)), entity.index, None, entity.variable_types)
@@ -200,10 +195,9 @@ def dask_home_games_es(pd_home_games_es):
 
 @pytest.fixture
 def ks_home_games_es(pd_home_games_es):
+    ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
-    if not ks:
-        pytest.skip('Koalas not installed, skipping Koalas tests')
     entities = {}
     for entity in pd_home_games_es.entities:
         entities[entity.id] = (ks.from_pandas(pd_to_ks_clean(entity.df)), entity.index, None, entity.variable_types)
@@ -238,10 +232,9 @@ def dd_mock_customer(pd_mock_customer):
 
 @pytest.fixture
 def ks_mock_customer(pd_mock_customer):
+    ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
-    if not ks:
-        pytest.skip('Koalas not installed, skipping Koalas tests')
     ks_mock_customer = copy.deepcopy(pd_mock_customer)
     for entity in ks_mock_customer.entities:
         cleaned_df = pd_to_ks_clean(entity.df).reset_index(drop=True)

--- a/featuretools/tests/conftest.py
+++ b/featuretools/tests/conftest.py
@@ -12,13 +12,14 @@ from featuretools.utils.gen_utils import import_or_none
 from featuretools.utils.koalas_utils import pd_to_ks_clean
 
 ks = import_or_none('databricks.koalas')
-SparkSession = import_or_none('pyspark.sql.SparkSession')
+sql = import_or_none('pyspark.sql')
 
 
 @pytest.fixture(scope='session', autouse=True)
 def spark_session():
-    if not SparkSession:
+    if not sql:
         return
+    SparkSession = sql.SparkSession
     spark = SparkSession.builder \
         .master('local[2]') \
         .config("spark.driver.extraJavaOptions", "-Dio.netty.tryReflectionSetAccessible=True") \

--- a/featuretools/tests/conftest.py
+++ b/featuretools/tests/conftest.py
@@ -3,22 +3,22 @@ import sys
 
 import dask
 import dask.dataframe as dd
-import databricks.koalas as ks
 import pandas as pd
 import pytest
-from pyspark.sql import SparkSession
 
 import featuretools as ft
 from featuretools.tests.testing_utils import make_ecommerce_entityset
 from featuretools.utils.koalas_utils import pd_to_ks_clean
+from featuretools.utils.gen_utils import import_or_none
+
+ks = import_or_none('databricks.koalas')
+SparkSession = import_or_none('pyspark.sql.SparkSession')
 
 
 @pytest.fixture(scope='session', autouse=True)
-def spark_session(request):
-    ''' fixture for creating a spark context
-    Args:
-        request: pytest.fixtureRequest object
-    '''
+def spark_session():
+    if not SparkSession:
+        return
     spark = SparkSession.builder \
         .master('local[2]') \
         .config("spark.driver.extraJavaOptions", "-Dio.netty.tryReflectionSetAccessible=True") \
@@ -61,6 +61,8 @@ def dask_es(make_es):
 def ks_es(make_es):
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
+    if not ks:
+        pytest.skip('Koalas not installed, skipping Koalas tests')
     ks_es = copy.deepcopy(make_es)
     for entity in ks_es.entities:
         cleaned_df = pd_to_ks_clean(entity.df).reset_index(drop=True)
@@ -143,6 +145,8 @@ def dask_diamond_es(pd_diamond_es):
 def ks_diamond_es(pd_diamond_es):
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
+    if not ks:
+        pytest.skip('Koalas not installed, skipping')
     entities = {}
     for entity in pd_diamond_es.entities:
         entities[entity.id] = (ks.from_pandas(pd_to_ks_clean(entity.df)), entity.index, None, entity.variable_types)
@@ -197,6 +201,8 @@ def dask_home_games_es(pd_home_games_es):
 def ks_home_games_es(pd_home_games_es):
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
+    if not ks:
+        pytest.skip('Koalas not installed, skipping Koalas tests')
     entities = {}
     for entity in pd_home_games_es.entities:
         entities[entity.id] = (ks.from_pandas(pd_to_ks_clean(entity.df)), entity.index, None, entity.variable_types)
@@ -233,6 +239,8 @@ def dd_mock_customer(pd_mock_customer):
 def ks_mock_customer(pd_mock_customer):
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
+    if not ks:
+        pytest.skip('Koalas not installed, skipping Koalas tests')
     ks_mock_customer = copy.deepcopy(pd_mock_customer)
     for entity in ks_mock_customer.entities:
         cleaned_df = pd_to_ks_clean(entity.df).reset_index(drop=True)

--- a/featuretools/tests/entityset_tests/test_entity.py
+++ b/featuretools/tests/entityset_tests/test_entity.py
@@ -11,8 +11,8 @@ from featuretools.tests.testing_utils import (
     make_ecommerce_entityset,
     to_pandas
 )
-from featuretools.variable_types import find_variable_types
 from featuretools.utils.gen_utils import import_or_none
+from featuretools.variable_types import find_variable_types
 
 ks = import_or_none('databricks.koalas')
 

--- a/featuretools/tests/entityset_tests/test_entity.py
+++ b/featuretools/tests/entityset_tests/test_entity.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-import databricks.koalas as ks
 import numpy as np
 import pandas as pd
 import pytest
@@ -13,6 +12,9 @@ from featuretools.tests.testing_utils import (
     to_pandas
 )
 from featuretools.variable_types import find_variable_types
+from featuretools.utils.gen_utils import import_or_none
+
+ks = import_or_none('databricks.koalas')
 
 
 def test_enforces_variable_id_is_str(es):
@@ -85,7 +87,7 @@ def test_eq(es):
 
 def test_update_data(es):
     df = es['customers'].df.copy()
-    if isinstance(df, ks.DataFrame):
+    if ks and isinstance(df, ks.DataFrame):
         df['new'] = [1, 2, 3]
     else:
         df['new'] = pd.Series([1, 2, 3])
@@ -104,7 +106,7 @@ def test_update_data(es):
     updated_id.iloc[1] = 2
     updated_id.iloc[2] = 1
 
-    if isinstance(df, ks.DataFrame):
+    if ks and isinstance(df, ks.DataFrame):
         df["id"] = updated_id.to_list()
         df = df.sort_index()
     else:
@@ -121,7 +123,7 @@ def test_update_data(es):
     updated_signup = to_pandas(df['signup_date'])
     updated_signup.iloc[0] = datetime(2011, 4, 11)
 
-    if isinstance(df, ks.DataFrame):
+    if ks and isinstance(df, ks.DataFrame):
         df['signup_date'] = updated_signup.to_list()
         df = df.sort_index()
     else:

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -4,7 +4,6 @@ import sys
 from datetime import datetime
 
 import dask.dataframe as dd
-import databricks.koalas as ks
 import numpy as np
 import pandas as pd
 import pytest
@@ -20,6 +19,9 @@ from featuretools.entityset import (
 from featuretools.entityset.serialize import SCHEMA_VERSION
 from featuretools.tests.testing_utils import to_pandas
 from featuretools.utils.koalas_utils import pd_to_ks_clean
+from featuretools.utils.gen_utils import import_or_none
+
+ks = import_or_none('databricks.koalas')
 
 
 def test_normalize_time_index_as_additional_variable(es):
@@ -40,7 +42,7 @@ def test_operations_invalidate_metadata(es):
     assert new_es._data_description is None
     assert new_es.metadata is not None  # generated after access
     assert new_es._data_description is not None
-    if isinstance(es['customers'].df, (dd.DataFrame, ks.DataFrame)):
+    if not isinstance(es['customers'].df, pd.DataFrame):
         customers_vtypes = es["customers"].variable_types
         customers_vtypes['signup_date'] = variable_types.Datetime
     else:
@@ -49,7 +51,7 @@ def test_operations_invalidate_metadata(es):
                                  es["customers"].df,
                                  index=es["customers"].index,
                                  variable_types=customers_vtypes)
-    if isinstance(es['sessions'].df, (dd.DataFrame, ks.DataFrame)):
+    if not isinstance(es['sessions'].df, pd.DataFrame):
         sessions_vtypes = es["sessions"].variable_types
     else:
         sessions_vtypes = None
@@ -113,7 +115,7 @@ def test_add_relationships_convert_type(es):
 
 # TODO: Koalas does not support categorical types
 def test_add_relationship_errors_on_dtype_mismatch(es):
-    if isinstance(es['customers'].df, ks.DataFrame):
+    if ks and isinstance(es['customers'].df, ks.DataFrame):
         pytest.xfail('Koalas does not support categorical types')
     log_2_df = es['log'].df.copy()
     log_variable_types = {
@@ -234,6 +236,8 @@ def dd_df(pd_df):
 def ks_df(pd_df):
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
+    if not ks:
+        pytest.skip('Koalas not installed, skipping')
     return ks.from_pandas(pd_df)
 
 
@@ -300,6 +304,8 @@ def dd_df2(pd_df2):
 def ks_df2(pd_df2):
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
+    if not ks:
+        pytest.skip('Koalas not installed, skipping')
     return ks.from_pandas(pd_df2)
 
 
@@ -335,6 +341,8 @@ def dd_df3(pd_df3):
 def ks_df3(pd_df3):
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
+    if not ks:
+        pytest.skip('Koalas not installed, skipping')
     return ks.from_pandas(pd_df3)
 
 
@@ -396,6 +404,8 @@ def dd_df4(pd_df4):
 def ks_df4(pd_df4):
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
+    if not ks:
+        pytest.skip('Koalas not installed, skipping')
     return ks.from_pandas(pd_to_ks_clean(pd_df4))
 
 
@@ -408,7 +418,7 @@ def test_converts_variable_types_on_init(df4):
     vtypes = {'id': variable_types.Categorical,
               'ints': variable_types.Numeric,
               'floats': variable_types.Numeric}
-    if isinstance(df4, (dd.DataFrame, ks.DataFrame)):
+    if not isinstance(df4, pd.DataFrame):
         vtypes['category'] = variable_types.Categorical
         vtypes['category_int'] = variable_types.Categorical
     es = EntitySet(id='test')
@@ -425,10 +435,10 @@ def test_converts_variable_types_on_init(df4):
 
 
 def test_converts_variable_type_after_init(df4):
-    if isinstance(df4, ks.DataFrame):
+    if ks and isinstance(df4, ks.DataFrame):
         pytest.xfail("Koalas doesn't support category dtype")
     df4["category"] = df4["category"].astype("category")
-    if isinstance(df4, (dd.DataFrame, ks.DataFrame)):
+    if not isinstance(df4, pd.DataFrame):
         vtypes = {'id': variable_types.Categorical,
                   'category': variable_types.Categorical,
                   'category_int': variable_types.Categorical,
@@ -492,6 +502,8 @@ def dd_datetime1(pd_datetime1):
 def ks_datetime1(pd_datetime1):
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
+    if not ks:
+        pytest.skip('Koalas not installed, skipping')
     return ks.from_pandas(pd_datetime1)
 
 
@@ -537,6 +549,8 @@ def dd_datetime2(pd_datetime2):
 def ks_datetime2(pd_datetime2):
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
+    if not ks:
+        pytest.skip('Koalas not installed, skipping')
     return ks.from_pandas(pd_datetime2)
 
 
@@ -595,11 +609,11 @@ def test_entity_init(es):
                        'number': [4, 5, 6]})
     if any(isinstance(entity.df, dd.DataFrame) for entity in es.entities):
         df = dd.from_pandas(df, npartitions=2)
-    if any(isinstance(entity.df, ks.DataFrame) for entity in es.entities):
+    if ks and any(isinstance(entity.df, ks.DataFrame) for entity in es.entities):
         df = ks.from_pandas(df)
 
     vtypes = {'time': variable_types.Datetime}
-    if isinstance(df, (dd.DataFrame, ks.DataFrame)):
+    if not isinstance(df, pd.DataFrame):
         extra_vtypes = {
             'id': variable_types.Categorical,
             'category': variable_types.Categorical,
@@ -622,7 +636,7 @@ def test_entity_init(es):
     assert set([v.id for v in es['test_entity'].variables]) == set(df.columns)
 
     assert es['test_entity'].df['time'].dtype == df['time'].dtype
-    if isinstance(es['test_entity'].df, ks.DataFrame):
+    if ks and isinstance(es['test_entity'].df, ks.DataFrame):
         assert set(es['test_entity'].df['id'].to_list()) == set(df['id'].to_list())
     else:
         assert set(es['test_entity'].df['id']) == set(df['id'])
@@ -693,7 +707,7 @@ def test_concat_entitysets(es):
         pytest.xfail("Dask has no .equals method and issue with categoricals "
                      "and add_last_time_indexes")
         df = dd.from_pandas(df, npartitions=2)
-    if any(isinstance(entity.df, ks.DataFrame) for entity in es.entities):
+    if ks and any(isinstance(entity.df, ks.DataFrame) for entity in es.entities):
         pytest.xfail("Koalas deepcopy fails")
         df = ks.from_pandas(df)
 
@@ -797,6 +811,8 @@ def dd_transactions_df(pd_transactions_df):
 def ks_transactions_df(pd_transactions_df):
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
+    if not ks:
+        pytest.skip('Koalas not installed, skipping')
     return ks.from_pandas(pd_transactions_df)
 
 
@@ -810,9 +826,9 @@ def test_set_time_type_on_init(transactions_df):
     cards_df = pd.DataFrame({"id": [1, 2, 3, 4, 5]})
     if isinstance(transactions_df, dd.DataFrame):
         cards_df = dd.from_pandas(cards_df, npartitions=3)
-    if isinstance(transactions_df, ks.DataFrame):
+    if ks and isinstance(transactions_df, ks.DataFrame):
         cards_df = ks.from_pandas(cards_df)
-    if isinstance(transactions_df, (dd.DataFrame, ks.DataFrame)):
+    if not isinstance(transactions_df, pd.DataFrame):
         cards_vtypes = {'id': variable_types.Categorical}
         transactions_vtypes = {
             'id': variable_types.Categorical,
@@ -845,9 +861,9 @@ def test_sets_time_when_adding_entity(transactions_df):
                                                        "editable"]})
     if isinstance(transactions_df, dd.DataFrame):
         accounts_df = dd.from_pandas(accounts_df, npartitions=2)
-    if isinstance(transactions_df, ks.DataFrame):
+    if ks and isinstance(transactions_df, ks.DataFrame):
         accounts_df = ks.from_pandas(accounts_df)
-    if isinstance(transactions_df, (dd.DataFrame, ks.DataFrame)):
+    if not isinstance(transactions_df, pd.DataFrame):
         accounts_vtypes = {'id': variable_types.Categorical, 'signup_date': variable_types.Datetime}
         transactions_vtypes = {
             'id': variable_types.Categorical,
@@ -898,11 +914,11 @@ def test_sets_time_when_adding_entity(transactions_df):
 
 def test_checks_time_type_setting_time_index(es):
     # set non time type as time index, Dask and Pandas error differently
-    if isinstance(es['log'].df, (pd.DataFrame, ks.DataFrame)):
-        error_text = 'log time index not recognized as numeric or datetime'
-    else:
+    if isinstance(es['log'].df, dd.DataFrame):
         error_text = "log time index is %s type which differs from" \
                      " other entityset time indexes" % (variable_types.NumericTimeIndex)
+    else:
+        error_text = 'log time index not recognized as numeric or datetime'
     with pytest.raises(TypeError, match=error_text):
         es['log'].set_time_index('purchased')
 
@@ -1144,7 +1160,7 @@ def test_normalize_entity_same_index(es):
 
 # TODO: normalize entity fails with Dask, doesn't specify all vtypes when creating new entity
 def test_secondary_time_index(es):
-    if any(isinstance(entity.df, (dd.DataFrame, ks.DataFrame)) for entity in es.entities):
+    if not all(isinstance(entity.df, pd.DataFrame) for entity in es.entities):
         pytest.xfail('vtype error when attempting to normalize entity')
     es.normalize_entity('log', 'values', 'value',
                         make_time_index=True,
@@ -1203,6 +1219,8 @@ def dd_datetime3(pd_datetime3):
 def ks_datetime3(pd_datetime3):
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
+    if not ks:
+        pytest.skip('Koalas not installed, skipping')
     return ks.from_pandas(pd_datetime3)
 
 
@@ -1214,12 +1232,12 @@ def datetime3(request):
 def test_datetime64_conversion(datetime3):
     df = datetime3
     df["time"] = pd.Timestamp.now()
-    if isinstance(df, ks.DataFrame):
+    if ks and isinstance(df, ks.DataFrame):
         df['time'] = df['time'].astype(np.datetime64)
     else:
         df["time"] = df["time"].astype("datetime64[ns, UTC]")
 
-    if isinstance(df, (dd.DataFrame, ks.DataFrame)):
+    if not isinstance(df, pd.DataFrame):
         vtypes = {
             'id': variable_types.Categorical,
             'ints': variable_types.Numeric,
@@ -1317,6 +1335,8 @@ def dd_index_df(pd_index_df):
 def ks_index_df(pd_index_df):
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
+    if not ks:
+        pytest.skip('Koalas not installed, skipping')
     return ks.from_pandas(pd_index_df)
 
 
@@ -1326,7 +1346,7 @@ def index_df(request):
 
 
 def test_same_index_values(index_df):
-    if isinstance(index_df, (dd.DataFrame, ks.DataFrame)):
+    if not isinstance(index_df, pd.DataFrame):
         vtypes = {
             'id': variable_types.Categorical,
             'transaction_time': variable_types.Datetime,
@@ -1359,7 +1379,7 @@ def test_same_index_values(index_df):
 
 
 def test_use_time_index(index_df):
-    if isinstance(index_df, (dd.DataFrame, ks.DataFrame)):
+    if not isinstance(index_df, pd.DataFrame):
         bad_vtypes = {
             'id': variable_types.Categorical,
             'transaction_time': variable_types.DatetimeTimeIndex,

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -234,10 +234,9 @@ def dd_df(pd_df):
 
 @pytest.fixture
 def ks_df(pd_df):
+    ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
-    if not ks:
-        pytest.skip('Koalas not installed, skipping')
     return ks.from_pandas(pd_df)
 
 
@@ -302,10 +301,9 @@ def dd_df2(pd_df2):
 
 @pytest.fixture
 def ks_df2(pd_df2):
+    ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
-    if not ks:
-        pytest.skip('Koalas not installed, skipping')
     return ks.from_pandas(pd_df2)
 
 
@@ -339,10 +337,9 @@ def dd_df3(pd_df3):
 
 @pytest.fixture
 def ks_df3(pd_df3):
+    ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
-    if not ks:
-        pytest.skip('Koalas not installed, skipping')
     return ks.from_pandas(pd_df3)
 
 
@@ -402,10 +399,9 @@ def dd_df4(pd_df4):
 
 @pytest.fixture
 def ks_df4(pd_df4):
+    ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
-    if not ks:
-        pytest.skip('Koalas not installed, skipping')
     return ks.from_pandas(pd_to_ks_clean(pd_df4))
 
 
@@ -500,10 +496,9 @@ def dd_datetime1(pd_datetime1):
 
 @pytest.fixture
 def ks_datetime1(pd_datetime1):
+    ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
-    if not ks:
-        pytest.skip('Koalas not installed, skipping')
     return ks.from_pandas(pd_datetime1)
 
 
@@ -547,10 +542,9 @@ def dd_datetime2(pd_datetime2):
 
 @pytest.fixture
 def ks_datetime2(pd_datetime2):
+    ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
-    if not ks:
-        pytest.skip('Koalas not installed, skipping')
     return ks.from_pandas(pd_datetime2)
 
 
@@ -809,10 +803,9 @@ def dd_transactions_df(pd_transactions_df):
 
 @pytest.fixture
 def ks_transactions_df(pd_transactions_df):
+    ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
-    if not ks:
-        pytest.skip('Koalas not installed, skipping')
     return ks.from_pandas(pd_transactions_df)
 
 
@@ -1217,10 +1210,9 @@ def dd_datetime3(pd_datetime3):
 
 @pytest.fixture
 def ks_datetime3(pd_datetime3):
+    ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
-    if not ks:
-        pytest.skip('Koalas not installed, skipping')
     return ks.from_pandas(pd_datetime3)
 
 
@@ -1333,10 +1325,9 @@ def dd_index_df(pd_index_df):
 
 @pytest.fixture
 def ks_index_df(pd_index_df):
+    ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
-    if not ks:
-        pytest.skip('Koalas not installed, skipping')
     return ks.from_pandas(pd_index_df)
 
 

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -18,8 +18,8 @@ from featuretools.entityset import (
 )
 from featuretools.entityset.serialize import SCHEMA_VERSION
 from featuretools.tests.testing_utils import to_pandas
-from featuretools.utils.koalas_utils import pd_to_ks_clean
 from featuretools.utils.gen_utils import import_or_none
+from featuretools.utils.koalas_utils import pd_to_ks_clean
 
 ks = import_or_none('databricks.koalas')
 

--- a/featuretools/tests/entityset_tests/test_es_metadata.py
+++ b/featuretools/tests/entityset_tests/test_es_metadata.py
@@ -7,9 +7,6 @@ from dask import dataframe as dd
 import featuretools as ft
 from featuretools import EntitySet, Relationship, variable_types
 from featuretools.tests.testing_utils import backward_path, forward_path
-from featuretools.utils.gen_utils import import_or_none
-
-ks = import_or_none('databricks.koalas')
 
 
 def test_cannot_re_add_relationships_that_already_exists(es):
@@ -152,10 +149,9 @@ def dd_employee_df(pd_employee_df):
 
 @pytest.fixture
 def ks_employee_df(pd_employee_df):
+    ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
-    if not ks:
-        pytest.skip('Koalas not installed, skipping')
     return ks.from_pandas(pd_employee_df)
 
 

--- a/featuretools/tests/entityset_tests/test_es_metadata.py
+++ b/featuretools/tests/entityset_tests/test_es_metadata.py
@@ -3,11 +3,13 @@ import sys
 import pandas as pd
 import pytest
 from dask import dataframe as dd
-from databricks import koalas as ks
 
 import featuretools as ft
 from featuretools import EntitySet, Relationship, variable_types
 from featuretools.tests.testing_utils import backward_path, forward_path
+from featuretools.utils.gen_utils import import_or_none
+
+ks = import_or_none('databricks.koalas')
 
 
 def test_cannot_re_add_relationships_that_already_exists(es):
@@ -152,6 +154,8 @@ def dd_employee_df(pd_employee_df):
 def ks_employee_df(pd_employee_df):
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
+    if not ks:
+        pytest.skip('Koalas not installed, skipping')
     return ks.from_pandas(pd_employee_df)
 
 

--- a/featuretools/tests/entityset_tests/test_koalas_es.py
+++ b/featuretools/tests/entityset_tests/test_koalas_es.py
@@ -1,12 +1,15 @@
-import databricks.koalas as ks
 import pandas as pd
 import pytest
 
 import featuretools as ft
 from featuretools.entityset import EntitySet, Relationship
 from featuretools.utils.koalas_utils import pd_to_ks_clean
+from featuretools.utils.gen_utils import import_or_none
+
+ks = import_or_none('databricks.koalas')
 
 
+@pytest.mark.skipif('not ks')
 def test_create_entity_from_ks_df(pd_es):
     cleaned_df = pd_to_ks_clean(pd_es["log"].df)
     log_ks = ks.from_pandas(cleaned_df)
@@ -22,6 +25,7 @@ def test_create_entity_from_ks_df(pd_es):
     pd.testing.assert_frame_equal(cleaned_df, ks_es["log_ks"].df.to_pandas(), check_like=True)
 
 
+@pytest.mark.skipif('not ks')
 def test_create_entity_with_non_numeric_index(pd_es, ks_es):
     df = pd.DataFrame({"id": ["A_1", "A_2", "C", "D"],
                        "values": [1, 12, -34, 27]})
@@ -40,6 +44,7 @@ def test_create_entity_with_non_numeric_index(pd_es, ks_es):
     pd.testing.assert_frame_equal(pd_es['new_entity'].df.reset_index(drop=True), ks_es['new_entity'].df.to_pandas())
 
 
+@pytest.mark.skipif('not ks')
 def test_create_entityset_with_mixed_dataframe_types(pd_es, ks_es):
     df = pd.DataFrame({"id": [0, 1, 2, 3],
                        "values": [1, 12, -34, 27]})
@@ -68,6 +73,7 @@ def test_create_entityset_with_mixed_dataframe_types(pd_es, ks_es):
             index="id")
 
 
+@pytest.mark.skipif('not ks')
 def test_add_last_time_indexes():
     pd_es = EntitySet(id="pd_es")
     ks_es = EntitySet(id="ks_es")
@@ -128,6 +134,7 @@ def test_add_last_time_indexes():
     pd.testing.assert_series_equal(pd_es['sessions'].last_time_index.sort_index(), ks_es['sessions'].last_time_index.to_pandas().sort_index(), check_names=False)
 
 
+@pytest.mark.skipif('not ks')
 def test_create_entity_with_make_index():
     values = [1, 12, -23, 27]
     df = pd.DataFrame({"values": values})
@@ -140,6 +147,7 @@ def test_create_entity_with_make_index():
     pd.testing.assert_frame_equal(expected_df, ks_es['new_entity'].df.to_pandas().sort_index())
 
 
+@pytest.mark.skipif('not ks')
 def test_single_table_ks_entityset():
     primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
 
@@ -185,6 +193,7 @@ def test_single_table_ks_entityset():
     pd.testing.assert_frame_equal(fm, ks_computed_fm, check_dtype=False)
 
 
+@pytest.mark.skipif('not ks')
 def test_single_table_ks_entityset_ids_not_sorted():
     primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
 
@@ -229,6 +238,7 @@ def test_single_table_ks_entityset_ids_not_sorted():
     pd.testing.assert_frame_equal(fm, ks_fm.to_pandas().set_index('id').loc[fm.index], check_dtype=False)
 
 
+@pytest.mark.skipif('not ks')
 def test_single_table_ks_entityset_with_instance_ids():
     primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
     instance_ids = [0, 1, 3]
@@ -277,6 +287,7 @@ def test_single_table_ks_entityset_with_instance_ids():
     pd.testing.assert_frame_equal(fm, ks_fm.to_pandas().set_index('id').loc[fm.index], check_dtype=False)
 
 
+@pytest.mark.skipif('not ks')
 def test_single_table_ks_entityset_single_cutoff_time():
     primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
 
@@ -323,6 +334,7 @@ def test_single_table_ks_entityset_single_cutoff_time():
     pd.testing.assert_frame_equal(fm, ks_fm.to_pandas().set_index('id').loc[fm.index], check_dtype=False)
 
 
+@pytest.mark.skipif('not ks')
 def test_single_table_ks_entityset_cutoff_time_df():
     primitives_list = ['absolute', 'is_weekend', 'year', 'day', 'num_characters', 'num_words']
 
@@ -379,6 +391,7 @@ def test_single_table_ks_entityset_cutoff_time_df():
     pd.testing.assert_frame_equal(fm, ks_fm)
 
 
+@pytest.mark.skipif('not ks')
 def test_single_table_ks_entityset_dates_not_sorted():
     ks_es = EntitySet(id="ks_es")
     df = pd.DataFrame({"id": [0, 1, 2, 3],
@@ -420,6 +433,7 @@ def test_single_table_ks_entityset_dates_not_sorted():
     pd.testing.assert_frame_equal(fm, ks_fm.to_pandas().set_index('id').loc[fm.index])
 
 
+@pytest.mark.skipif('not ks')
 def test_secondary_time_index():
     log_df = pd.DataFrame()
     log_df['id'] = [0, 1, 2, 3]

--- a/featuretools/tests/entityset_tests/test_koalas_es.py
+++ b/featuretools/tests/entityset_tests/test_koalas_es.py
@@ -3,8 +3,8 @@ import pytest
 
 import featuretools as ft
 from featuretools.entityset import EntitySet, Relationship
-from featuretools.utils.koalas_utils import pd_to_ks_clean
 from featuretools.utils.gen_utils import import_or_none
+from featuretools.utils.koalas_utils import pd_to_ks_clean
 
 ks = import_or_none('databricks.koalas')
 

--- a/featuretools/tests/entityset_tests/test_plotting.py
+++ b/featuretools/tests/entityset_tests/test_plotting.py
@@ -8,9 +8,6 @@ import pytest
 from dask import dataframe as dd
 
 import featuretools as ft
-from featuretools.utils.gen_utils import import_or_none
-
-ks = import_or_none('databricks.koalas')
 
 
 @pytest.fixture
@@ -32,10 +29,9 @@ def dd_simple():
 
 @pytest.fixture
 def ks_simple():
+    ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
-    if not ks:
-        pytest.skip('Koalas not installed, skipping')
     es = ft.EntitySet("test")
     df = ks.DataFrame({'foo': [1]})
     es.entity_from_dataframe('test', df)

--- a/featuretools/tests/entityset_tests/test_plotting.py
+++ b/featuretools/tests/entityset_tests/test_plotting.py
@@ -6,9 +6,11 @@ import graphviz
 import pandas as pd
 import pytest
 from dask import dataframe as dd
-from databricks import koalas as ks
 
 import featuretools as ft
+from featuretools.utils.gen_utils import import_or_none
+
+ks = import_or_none('databricks.koalas')
 
 
 @pytest.fixture
@@ -32,6 +34,8 @@ def dd_simple():
 def ks_simple():
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
+    if not ks:
+        pytest.skip('Koalas not installed, skipping')
     es = ft.EntitySet("test")
     df = ks.DataFrame({'foo': [1]})
     es.entity_from_dataframe('test', df)

--- a/featuretools/tests/entityset_tests/test_serialization.py
+++ b/featuretools/tests/entityset_tests/test_serialization.py
@@ -7,13 +7,13 @@ import pytest
 
 from featuretools.entityset import EntitySet, deserialize, serialize
 from featuretools.tests.testing_utils import to_pandas
+from featuretools.utils.gen_utils import import_or_none
 from featuretools.variable_types import (
     Categorical,
     Index,
     TimeIndex,
     find_variable_types
 )
-from featuretools.utils.gen_utils import import_or_none
 
 ks = import_or_none('databricks.koalas')
 

--- a/featuretools/tests/entityset_tests/test_serialization.py
+++ b/featuretools/tests/entityset_tests/test_serialization.py
@@ -4,8 +4,6 @@ import os
 import boto3
 import pandas as pd
 import pytest
-from dask import dataframe as dd
-from databricks import koalas as ks
 
 from featuretools.entityset import EntitySet, deserialize, serialize
 from featuretools.tests.testing_utils import to_pandas
@@ -15,6 +13,10 @@ from featuretools.variable_types import (
     TimeIndex,
     find_variable_types
 )
+from featuretools.utils.gen_utils import import_or_none
+
+ks = import_or_none('databricks.koalas')
+
 
 BUCKET_NAME = "test-bucket"
 WRITE_KEY_NAME = "test-key"
@@ -239,7 +241,7 @@ def make_public(s3_client, s3_bucket):
 
 # TODO: tmp file disappears after deserialize step, cannot check equality with Dask
 def test_serialize_s3_csv(es, s3_client, s3_bucket):
-    if any(isinstance(entity.df, (dd.DataFrame, ks.DataFrame)) for entity in es.entities):
+    if not all(isinstance(entity.df, pd.DataFrame) for entity in es.entities):
         pytest.xfail('tmp file disappears after deserialize step, cannot check equality with Dask')
     es.to_csv(TEST_S3_URL, encoding='utf-8', engine='python')
     make_public(s3_client, s3_bucket)
@@ -257,7 +259,7 @@ def test_serialize_s3_pickle(pd_es, s3_client, s3_bucket):
 
 # TODO: tmp file disappears after deserialize step, cannot check equality with Dask, Koalas
 def test_serialize_s3_parquet(es, s3_client, s3_bucket):
-    if any(isinstance(entity.df, (dd.DataFrame, ks.DataFrame)) for entity in es.entities):
+    if not all(isinstance(entity.df, pd.DataFrame) for entity in es.entities):
         pytest.xfail('tmp file disappears after deserialize step, cannot check equality with Dask or Koalas')
     es.to_parquet(TEST_S3_URL)
     make_public(s3_client, s3_bucket)
@@ -267,7 +269,7 @@ def test_serialize_s3_parquet(es, s3_client, s3_bucket):
 
 # TODO: tmp file disappears after deserialize step, cannot check equality with Dask, Koalas
 def test_serialize_s3_anon_csv(es, s3_client, s3_bucket):
-    if any(isinstance(entity.df, (dd.DataFrame, ks.DataFrame)) for entity in es.entities):
+    if not all(isinstance(entity.df, pd.DataFrame) for entity in es.entities):
         pytest.xfail('tmp file disappears after deserialize step, cannot check equality with Dask or Koalas')
     es.to_csv(TEST_S3_URL, encoding='utf-8', engine='python', profile_name=False)
     make_public(s3_client, s3_bucket)
@@ -285,7 +287,7 @@ def test_serialize_s3_anon_pickle(pd_es, s3_client, s3_bucket):
 
 # TODO: tmp file disappears after deserialize step, cannot check equality with Dask
 def test_serialize_s3_anon_parquet(es, s3_client, s3_bucket):
-    if any(isinstance(entity.df, (dd.DataFrame, ks.DataFrame)) for entity in es.entities):
+    if not all(isinstance(entity.df, pd.DataFrame) for entity in es.entities):
         pytest.xfail('tmp file disappears after deserialize step, cannot check equality with Dask')
     es.to_parquet(TEST_S3_URL, profile_name=False)
     make_public(s3_client, s3_bucket)
@@ -332,7 +334,7 @@ def setup_test_profile(monkeypatch, tmpdir):
 
 
 def test_s3_test_profile(es, s3_client, s3_bucket, setup_test_profile):
-    if any(isinstance(entity.df, (dd.DataFrame, ks.DataFrame)) for entity in es.entities):
+    if not all(isinstance(entity.df, pd.DataFrame) for entity in es.entities):
         pytest.xfail('tmp file disappears after deserialize step, cannot check equality with Dask')
     es.to_csv(TEST_S3_URL, encoding='utf-8', engine='python', profile_name='test')
     make_public(s3_client, s3_bucket)
@@ -351,7 +353,7 @@ def test_serialize_subdirs_not_removed(es, tmpdir):
     test_dir = write_path.mkdir("test_dir")
     with open(str(write_path.join('data_description.json')), 'w') as f:
         json.dump('__SAMPLE_TEXT__', f)
-    if any(isinstance(e.df, ks.DataFrame) for e in es.entities):
+    if ks and any(isinstance(e.df, ks.DataFrame) for e in es.entities):
         compression = 'none'
     else:
         compression = None

--- a/featuretools/tests/primitive_tests/test_agg_feats.py
+++ b/featuretools/tests/primitive_tests/test_agg_feats.py
@@ -38,6 +38,7 @@ from featuretools.tests.testing_utils import (
     feature_with_name,
     to_pandas
 )
+from featuretools.utils.gen_utils import import_or_none
 from featuretools.variable_types import (
     Datetime,
     DatetimeTimeIndex,
@@ -46,7 +47,6 @@ from featuretools.variable_types import (
     Numeric,
     Variable
 )
-from featuretools.utils.gen_utils import import_or_none
 
 ks = import_or_none('databricks.koalas')
 

--- a/featuretools/tests/primitive_tests/test_dask_primitives.py
+++ b/featuretools/tests/primitive_tests/test_dask_primitives.py
@@ -26,6 +26,7 @@ def test_transform(pd_es, dask_es):
                           trans_primitives=trans_primitives,
                           agg_primitives=agg_primitives,
                           max_depth=2,
+                          max_features=20000,
                           features_only=True)
 
         dask_features = ft.dfs(entityset=dask_es,
@@ -33,6 +34,7 @@ def test_transform(pd_es, dask_es):
                                trans_primitives=trans_primitives,
                                agg_primitives=agg_primitives,
                                max_depth=2,
+                               max_features=20000,
                                features_only=True)
         assert features == dask_features
 

--- a/featuretools/tests/primitive_tests/test_dask_primitives.py
+++ b/featuretools/tests/primitive_tests/test_dask_primitives.py
@@ -26,7 +26,6 @@ def test_transform(pd_es, dask_es):
                           trans_primitives=trans_primitives,
                           agg_primitives=agg_primitives,
                           max_depth=2,
-                          max_features=20000,
                           features_only=True)
 
         dask_features = ft.dfs(entityset=dask_es,
@@ -34,7 +33,6 @@ def test_transform(pd_es, dask_es):
                                trans_primitives=trans_primitives,
                                agg_primitives=agg_primitives,
                                max_depth=2,
-                               max_features=20000,
                                features_only=True)
         assert features == dask_features
 

--- a/featuretools/tests/primitive_tests/test_direct_features.py
+++ b/featuretools/tests/primitive_tests/test_direct_features.py
@@ -1,5 +1,3 @@
-import dask.dataframe as dd
-import databricks.koalas as ks
 import numpy as np
 import pandas as pd
 import pytest
@@ -89,7 +87,7 @@ def test_direct_copy(games_es):
 
 def test_direct_of_multi_output_transform_feat(es):
     # TODO: Update to work with Dask and Koalas
-    if any(isinstance(entity.df, (dd.DataFrame, ks.DataFrame)) for entity in es.entities):
+    if not all(isinstance(entity.df, pd.DataFrame) for entity in es.entities):
         pytest.xfail("Custom primitive is not compabible with Dask or Koalas")
 
     class TestTime(TransformPrimitive):

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -59,8 +59,8 @@ from featuretools.primitives.utils import (
 )
 from featuretools.synthesis.deep_feature_synthesis import match
 from featuretools.tests.testing_utils import feature_with_name, to_pandas
-from featuretools.variable_types import Boolean, Datetime, Numeric, Variable
 from featuretools.utils.gen_utils import import_or_none
+from featuretools.variable_types import Boolean, Datetime, Numeric, Variable
 
 ks = import_or_none('databricks.koalas')
 

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -41,10 +41,7 @@ from featuretools.primitives import (
 )
 from featuretools.synthesis import DeepFeatureSynthesis
 from featuretools.tests.testing_utils import feature_with_name
-from featuretools.utils.gen_utils import import_or_none
 from featuretools.variable_types import Datetime, Numeric
-
-ks = import_or_none('databricks.koalas')
 
 
 @pytest.fixture(params=['pd_transform_es', 'dask_transform_es', 'koalas_transform_es'])
@@ -80,10 +77,9 @@ def dask_transform_es(pd_transform_es):
 
 @pytest.fixture
 def koalas_transform_es(pd_transform_es):
+    ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
-    if not ks:
-        pytest.skip('Koalas not installed, skipping')
     es = ft.EntitySet(id=pd_transform_es.id)
     for entity in pd_transform_es.entities:
         es.entity_from_dataframe(entity_id=entity.id,

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -41,8 +41,8 @@ from featuretools.primitives import (
 )
 from featuretools.synthesis import DeepFeatureSynthesis
 from featuretools.tests.testing_utils import feature_with_name
-from featuretools.variable_types import Datetime, Numeric
 from featuretools.utils.gen_utils import import_or_none
+from featuretools.variable_types import Datetime, Numeric
 
 ks = import_or_none('databricks.koalas')
 

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -5,7 +5,6 @@ import numpy as np
 import pandas as pd
 import pytest
 from dask import dataframe as dd
-from databricks import koalas as ks
 from distributed.utils_test import cluster
 
 from featuretools import variable_types as vtypes
@@ -26,6 +25,9 @@ from featuretools.primitives import (
 from featuretools.synthesis import dfs
 from featuretools.tests.testing_utils import to_pandas
 from featuretools.variable_types import Numeric
+from featuretools.utils.gen_utils import import_or_none
+
+ks = import_or_none('databricks.koalas')
 
 
 @pytest.fixture(params=['pd_entities', 'dask_entities', 'koalas_entities'])
@@ -78,6 +80,8 @@ def dask_entities():
 def koalas_entities():
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
+    if not ks:
+        pytest.skip('Koalas not installed, skipping')
     cards_df = ks.DataFrame({"id": [1, 2, 3, 4, 5]})
     transactions_df = ks.DataFrame({"id": [1, 2, 3, 4, 5, 6],
                                     "card_id": [1, 2, 1, 3, 4, 5],
@@ -335,7 +339,7 @@ def test_accepts_pd_dateoffset_training_window(datetime_es):
 
 
 def test_warns_with_unused_primitives(es):
-    if any(isinstance(e.df, ks.DataFrame) for e in es.entities):
+    if ks and any(isinstance(e.df, ks.DataFrame) for e in es.entities):
         pytest.skip('Koalas throws extra warnings')
     trans_primitives = ['num_characters', 'num_words', 'add_numeric']
     agg_primitives = [Max, 'min']

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -24,8 +24,8 @@ from featuretools.primitives import (
 )
 from featuretools.synthesis import dfs
 from featuretools.tests.testing_utils import to_pandas
-from featuretools.variable_types import Numeric
 from featuretools.utils.gen_utils import import_or_none
+from featuretools.variable_types import Numeric
 
 ks = import_or_none('databricks.koalas')
 

--- a/featuretools/tests/synthesis/test_dfs_method.py
+++ b/featuretools/tests/synthesis/test_dfs_method.py
@@ -78,10 +78,9 @@ def dask_entities():
 
 @pytest.fixture
 def koalas_entities():
+    ks = pytest.importorskip('databricks.koalas', reason="Koalas not installed, skipping")
     if sys.platform.startswith('win'):
         pytest.skip('skipping Koalas tests for Windows')
-    if not ks:
-        pytest.skip('Koalas not installed, skipping')
     cards_df = ks.DataFrame({"id": [1, 2, 3, 4, 5]})
     transactions_df = ks.DataFrame({"id": [1, 2, 3, 4, 5, 6],
                                     "card_id": [1, 2, 1, 3, 4, 5],

--- a/featuretools/tests/testing_utils/es_utils.py
+++ b/featuretools/tests/testing_utils/es_utils.py
@@ -1,6 +1,9 @@
 import dask.dataframe as dd
-import databricks.koalas as ks
 import pandas as pd
+
+from featuretools.utils.gen_utils import import_or_none, is_instance
+
+ks = import_or_none('databricks.koalas')
 
 
 def to_pandas(df, index=None, sort_index=False, int_index=False):
@@ -20,7 +23,7 @@ def to_pandas(df, index=None, sort_index=False, int_index=False):
 
     if isinstance(df, (dd.DataFrame, dd.Series)):
         pd_df = df.compute()
-    if isinstance(df, (ks.DataFrame, ks.Series)):
+    if is_instance(df, (ks, ks), ('DataFrame', 'Series')):
         pd_df = df.to_pandas()
 
     if index:

--- a/featuretools/tests/utils_tests/test_gen_utils.py
+++ b/featuretools/tests/utils_tests/test_gen_utils.py
@@ -1,6 +1,12 @@
+import dask.dataframe as dd
+import pandas as pd
 import pytest
 
-from featuretools.utils.gen_utils import import_or_raise
+from featuretools.utils.gen_utils import (
+    import_or_none,
+    import_or_raise,
+    is_instance
+)
 
 
 def test_import_or_raise_errors():
@@ -11,3 +17,34 @@ def test_import_or_raise_errors():
 def test_import_or_raise_imports():
     math = import_or_raise("math", "error message")
     assert math.ceil(0.1) == 1
+
+
+def test_import_or_none():
+    math = import_or_none('math')
+    assert math.ceil(0.1) == 1
+
+    bad_lib = import_or_none('_featuretools')
+    assert bad_lib is None
+
+
+@pytest.fixture
+def df():
+    return pd.DataFrame({'id': range(5)})
+
+
+def test_is_instance_single_module(df):
+    assert is_instance(df, pd, 'DataFrame')
+
+
+def test_is_instance_multiple_modules(df):
+    df2 = dd.from_pandas(df, npartitions=2)
+    assert is_instance(df, (dd, pd), 'DataFrame')
+    assert is_instance(df2, (dd, pd), 'DataFrame')
+    assert is_instance(df2['id'], (dd, pd), ('Series', 'DataFrame'))
+    assert not is_instance(df2['id'], (dd, pd), ('DataFrame', 'Series'))
+
+
+def test_is_instance_none_module(df):
+    assert not is_instance(df, None, 'DataFrame')
+    assert is_instance(df, (None, pd), 'DataFrame')
+    assert is_instance(df, (None, pd), ('Series', 'DataFrame'))

--- a/featuretools/tests/utils_tests/test_gen_utils.py
+++ b/featuretools/tests/utils_tests/test_gen_utils.py
@@ -44,6 +44,12 @@ def test_is_instance_multiple_modules(df):
     assert not is_instance(df2['id'], (dd, pd), ('DataFrame', 'Series'))
 
 
+def test_is_instance_errors_mismatch():
+    msg = 'Number of modules does not match number of classnames'
+    with pytest.raises(ValueError, match=msg):
+        is_instance('abc', pd, ('DataFrame', 'Series'))
+
+
 def test_is_instance_none_module(df):
     assert not is_instance(df, None, 'DataFrame')
     assert is_instance(df, (None, pd), 'DataFrame')

--- a/featuretools/utils/entity_utils.py
+++ b/featuretools/utils/entity_utils.py
@@ -2,12 +2,14 @@ import warnings
 from datetime import datetime
 
 import dask.dataframe as dd
-import databricks.koalas as ks
 import numpy as np
 import pandas as pd
 import pandas.api.types as pdtypes
 
 from featuretools import variable_types as vtypes
+from featuretools.utils.gen_utils import import_or_none, is_instance
+
+ks = import_or_none('databricks.koalas')
 
 
 def infer_variable_types(df, link_vars, variable_types, time_index, secondary_time_index):
@@ -36,7 +38,7 @@ def infer_variable_types(df, link_vars, variable_types, time_index, secondary_ti
             msg = 'Variable types cannot be inferred from Dask DataFrames, ' \
                   'use variable_types to provide type metadata for entity'
             raise ValueError(msg)
-        elif isinstance(df, ks.DataFrame):
+        elif is_instance(df, ks, 'DataFrame'):
             msg = 'Variable types cannot be inferred from Koalas DataFrames, ' \
                   'use variable_types to provide type metadata for entity'
             raise ValueError(msg)
@@ -149,7 +151,7 @@ def convert_variable_data(df, column_id, new_type, **kwargs):
     if new_type == vtypes.Numeric:
         if isinstance(df, dd.DataFrame):
             df[column_id] = dd.to_numeric(df[column_id], errors='coerce')
-        elif isinstance(df, ks.DataFrame):
+        elif is_instance(df, ks, 'DataFrame'):
             df[column_id] = ks.to_numeric(df[column_id])
         else:
             orig_nonnull = df[column_id].dropna().shape[0]
@@ -167,7 +169,7 @@ def convert_variable_data(df, column_id, new_type, **kwargs):
         if isinstance(df, dd.DataFrame):
             df[column_id] = dd.to_datetime(df[column_id], format=format,
                                            infer_datetime_format=True)
-        elif isinstance(df, ks.DataFrame):
+        elif is_instance(df, ks, 'DataFrame'):
             df[column_id] = ks.to_datetime(df[column_id], format=format,
                                            infer_datetime_format=True)
         else:

--- a/featuretools/utils/gen_utils.py
+++ b/featuretools/utils/gen_utils.py
@@ -91,6 +91,43 @@ def import_or_raise(library, error_msg):
         raise ImportError(error_msg)
 
 
+def import_or_none(library):
+    '''
+    Attemps to import the requested library.
+
+    Args:
+        library (str): the name of the library
+    Returns: the library if it is installed, else None
+    '''
+    try:
+        return importlib.import_module(library)
+    except ImportError:
+        return None
+
+
 def camel_to_snake(s):
     s = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', s)
     return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s).lower()
+
+
+def is_instance(obj, modules, classnames):
+    '''
+    Check if the given object is an instance of classname in module(s). Module
+    can be None (i.e. not installed)
+
+    Args:
+        obj (obj): object to test
+        modules (module or tuple[module]): module to check, can be also be None (will be ignored)
+        classnames (str or tuple[str]): classname from module to check. If multiple values are
+                                        provided, they should match with a single module in order.
+                                        If a single value is provided, will be used for all modules.
+    Returns:
+        bool: True if object is an instance of classname from corresponding module, otherwise False.
+              Also returns False if the module is None (i.e. module is not installed)
+    '''
+    if type(modules) is not tuple:
+        modules = (modules, )
+    if type(classnames) is not tuple:
+        classnames = (classnames, ) * len(modules)
+    to_check = tuple(getattr(mod, classname, mod) for mod, classname in zip(modules, classnames) if mod)
+    return isinstance(obj, to_check)

--- a/featuretools/utils/gen_utils.py
+++ b/featuretools/utils/gen_utils.py
@@ -129,5 +129,7 @@ def is_instance(obj, modules, classnames):
         modules = (modules, )
     if type(classnames) is not tuple:
         classnames = (classnames, ) * len(modules)
+    if len(modules) != len(classnames):
+        raise ValueError('Number of modules does not match number of classnames')
     to_check = tuple(getattr(mod, classname, mod) for mod, classname in zip(modules, classnames) if mod)
     return isinstance(obj, to_check)

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ extras_require = {
   'nlp_primitives': ['nlp-primitives >= 0.2.2'],
   'autonormalize': ['autonormalize >= 1.0.0'],
   'sklearn_transformer': ['featuretools-sklearn-transformer >= 0.1.0'],
-  'koalas': ['pyspark >= 3.0.0', 'koalas >= 1.0.1']
+  'koalas': ['pyspark >= 3.0.0', 'koalas >= 1.1.0']
 }
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ extras_require = {
   'nlp_primitives': ['nlp-primitives >= 0.2.2'],
   'autonormalize': ['autonormalize >= 1.0.0'],
   'sklearn_transformer': ['featuretools-sklearn-transformer >= 0.1.0'],
+  'koalas': ['pyspark >= 3.0.0', 'koalas >= 1.0.1']
 }
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,5 +9,3 @@ moto>=1.3.13
 smart-open>=1.8.4
 boto3>=1.10.45
 composeml>=0.2.0
-pyspark>=3.0.0
-koalas>=1.0.1


### PR DESCRIPTION
Allow for Koalas to be an optional dependency:
- instead of importing directly, try to import and return None if we fail
- custom `is_instance` function which returns False if the module passed in is None, otherwise proceeds with this `isinstance` check as normal

See issue #1037 