### PR TITLE
Fix Koalas entity creation performance issue

### DIFF
--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -434,7 +434,7 @@ class Entity(object):
 
     def set_time_index(self, variable_id, already_sorted=False):
         # check time type
-        if isinstance(self.df, dd.DataFrame) or self.df.empty:
+        if isinstance(self.df, (dd.DataFrame, ks.DataFrame)) or self.df.empty:
             time_to_check = vtypes.DEFAULT_DTYPE_VALUES[self[variable_id]._default_pandas_dtype]
         else:
             time_to_check = self.df[variable_id].iloc[0]

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -897,8 +897,8 @@ def test_sets_time_when_adding_entity(transactions_df):
 
 
 def test_checks_time_type_setting_time_index(es):
-    # set non time type as time index, Dask and Pandas error differently
-    if isinstance(es['log'].df, (pd.DataFrame, ks.DataFrame)):
+    # set non time type as time index, Dask/Koalas and Pandas error differently
+    if isinstance(es['log'].df, pd.DataFrame):
         error_text = 'log time index not recognized as numeric or datetime'
     else:
         error_text = "log time index is %s type which differs from" \


### PR DESCRIPTION
Fix an issue with slow performance when using `iloc` when creating a Koalas entity. Follow same path as Dask entity creation.