### PR TITLE
Updates to improve Entity.query_by_values performance

### DIFF
--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -254,7 +254,7 @@ class Entity(object):
         else:
             if is_instance(instance_vals, (dd, ks), 'Series'):
                 df = self.df.merge(instance_vals.to_frame(), how="inner", on=variable_id)
-            elif isinstance(instance_vals, pd.Series) and isinstance(self.df, ks.DataFrame):
+            elif isinstance(instance_vals, pd.Series) and is_instance(self.df, ks, 'DataFrame'):
                 df = self.df.merge(ks.DataFrame({variable_id: instance_vals}), how="inner", on=variable_id)
             else:
                 df = self.df[self.df[variable_id].isin(instance_vals)]

--- a/featuretools/entityset/entity.py
+++ b/featuretools/entityset/entity.py
@@ -252,6 +252,8 @@ class Entity(object):
         else:
             if isinstance(instance_vals, dd.Series) or isinstance(instance_vals, ks.Series):
                 df = self.df.merge(instance_vals.to_frame(), how="inner", on=variable_id)
+            elif isinstance(instance_vals, pd.Series) and isinstance(self.df, ks.DataFrame):
+                df = self.df.merge(ks.DataFrame({variable_id: instance_vals}), how="inner", on=variable_id)
             else:
                 df = self.df[self.df[variable_id].isin(instance_vals)]
 

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -186,7 +186,7 @@ def test_query_by_id_with_time(es):
         instance_vals=[0, 1, 2, 3, 4],
         time_last=datetime(2011, 4, 9, 10, 30, 2 * 6))
     df = to_pandas(df)
-    if isinstance(es['log'].df, ks.DataFrame):
+    if ks and isinstance(es['log'].df, ks.DataFrame):
         # Koalas doesn't maintain order
         df = df.sort_values('id')
 
@@ -201,7 +201,7 @@ def test_query_by_variable_with_time(es):
 
     true_values = [
         i * 5 for i in range(5)] + [i * 1 for i in range(4)] + [0]
-    if isinstance(es['log'].df, ks.DataFrame):
+    if ks and isinstance(es['log'].df, ks.DataFrame):
         # Koalas doesn't maintain order
         df = df.sort_values('id')
 

--- a/featuretools/tests/entityset_tests/test_es.py
+++ b/featuretools/tests/entityset_tests/test_es.py
@@ -184,6 +184,10 @@ def test_query_by_id_with_time(es):
         instance_vals=[0, 1, 2, 3, 4],
         time_last=datetime(2011, 4, 9, 10, 30, 2 * 6))
     df = to_pandas(df)
+    if isinstance(es['log'].df, ks.DataFrame):
+        # Koalas doesn't maintain order
+        df = df.sort_values('id')
+
     assert list(df['id'].values) == [0, 1, 2]
 
 
@@ -195,6 +199,9 @@ def test_query_by_variable_with_time(es):
 
     true_values = [
         i * 5 for i in range(5)] + [i * 1 for i in range(4)] + [0]
+    if isinstance(es['log'].df, ks.DataFrame):
+        # Koalas doesn't maintain order
+        df = df.sort_values('id')
 
     assert list(df['id'].values) == list(range(10))
     assert list(df['value'].values) == true_values

--- a/featuretools/tests/entityset_tests/test_koalas_es.py
+++ b/featuretools/tests/entityset_tests/test_koalas_es.py
@@ -180,7 +180,7 @@ def test_single_table_ks_entityset():
                    target_entity="data",
                    trans_primitives=primitives_list)
 
-    ks_computed_fm = ks_fm.to_pandas().loc[fm.index][fm.columns]
+    ks_computed_fm = ks_fm.to_pandas().set_index('id').loc[fm.index][fm.columns]
     # NUM_WORDS(strings) is int32 in koalas for some reason
     pd.testing.assert_frame_equal(fm, ks_computed_fm, check_dtype=False)
 

--- a/featuretools/tests/primitive_tests/test_overrides.py
+++ b/featuretools/tests/primitive_tests/test_overrides.py
@@ -159,7 +159,9 @@ def test_override_cmp_from_variable(es):
 
     features = [count_lo]
 
-    df = to_pandas(ft.calculate_feature_matrix(entityset=es, features=features, instance_ids=[0, 1, 2]))
+    df = to_pandas(ft.calculate_feature_matrix(entityset=es, features=features, instance_ids=[0, 1, 2]),
+                   index='id',
+                   sort_index=True)
     v = df[count_lo.get_name()].values.tolist()
     for i, test in enumerate(to_test):
         assert v[i] == test

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -271,7 +271,9 @@ def test_compare_of_identity(es):
     for test in to_test:
         features.append(ft.Feature(es['log']['value'], primitive=test[0](10)))
 
-    df = to_pandas(ft.calculate_feature_matrix(entityset=es, features=features, instance_ids=[0, 1, 2, 3]))
+    df = to_pandas(ft.calculate_feature_matrix(entityset=es, features=features, instance_ids=[0, 1, 2, 3]),
+                   index='id',
+                   sort_index=True)
 
     for i, test in enumerate(to_test):
         v = df[features[i].get_name()].values.tolist()
@@ -684,7 +686,9 @@ def test_text_primitives(es):
 
     features = [words, chars]
 
-    df = to_pandas(ft.calculate_feature_matrix(entityset=es, features=features, instance_ids=range(15)))
+    df = to_pandas(ft.calculate_feature_matrix(entityset=es, features=features, instance_ids=range(15)),
+                   index='id',
+                   sort_index=True)
 
     word_counts = [514, 3, 3, 644, 1268, 1269, 177, 172, 79,
                    240, 1239, 3, 3, 3, 3]
@@ -702,7 +706,9 @@ def test_text_primitives(es):
 def test_isin_feat(es):
     isin = ft.Feature(es['log']['product_id'], primitive=IsIn(list_of_outputs=["toothpaste", "coke zero"]))
     features = [isin]
-    df = to_pandas(ft.calculate_feature_matrix(entityset=es, features=features, instance_ids=range(8)))
+    df = to_pandas(ft.calculate_feature_matrix(entityset=es, features=features, instance_ids=range(8)),
+                   index='id',
+                   sort_index=True)
     true = [True, True, True, False, False, True, True, True]
     v = df[isin.get_name()].values.tolist()
     assert true == v
@@ -711,7 +717,9 @@ def test_isin_feat(es):
 def test_isin_feat_other_syntax(es):
     isin = ft.Feature(es['log']['product_id']).isin(["toothpaste", "coke zero"])
     features = [isin]
-    df = to_pandas(ft.calculate_feature_matrix(entityset=es, features=features, instance_ids=range(8)))
+    df = to_pandas(ft.calculate_feature_matrix(entityset=es, features=features, instance_ids=range(8)),
+                   index='id',
+                   sort_index=True)
     true = [True, True, True, False, False, True, True, True]
     v = df[isin.get_name()].values.tolist()
     assert true == v
@@ -720,7 +728,9 @@ def test_isin_feat_other_syntax(es):
 def test_isin_feat_other_syntax_int(es):
     isin = ft.Feature(es['log']['value']).isin([5, 10])
     features = [isin]
-    df = to_pandas(ft.calculate_feature_matrix(entityset=es, features=features, instance_ids=range(8)))
+    df = to_pandas(ft.calculate_feature_matrix(entityset=es, features=features, instance_ids=range(8)),
+                   index='id',
+                   sort_index=True)
     true = [False, True, True, False, False, False, False, False]
     v = df[isin.get_name()].values.tolist()
     assert true == v
@@ -747,21 +757,27 @@ def test_isin_feat_custom(es):
 
     isin = ft.Feature(es['log']['product_id'], primitive=IsIn(list_of_outputs=["toothpaste", "coke zero"]))
     features = [isin]
-    df = to_pandas(ft.calculate_feature_matrix(entityset=es, features=features, instance_ids=range(8)))
+    df = to_pandas(ft.calculate_feature_matrix(entityset=es, features=features, instance_ids=range(8)),
+                   index='id',
+                   sort_index=True)
     true = [True, True, True, False, False, True, True, True]
     v = df[isin.get_name()].values.tolist()
     assert true == v
 
     isin = ft.Feature(es['log']['product_id']).isin(["toothpaste", "coke zero"])
     features = [isin]
-    df = to_pandas(ft.calculate_feature_matrix(entityset=es, features=features, instance_ids=range(8)))
+    df = to_pandas(ft.calculate_feature_matrix(entityset=es, features=features, instance_ids=range(8)),
+                   index='id',
+                   sort_index=True)
     true = [True, True, True, False, False, True, True, True]
     v = df[isin.get_name()].values.tolist()
     assert true == v
 
     isin = ft.Feature(es['log']['value']).isin([5, 10])
     features = [isin]
-    df = to_pandas(ft.calculate_feature_matrix(entityset=es, features=features, instance_ids=range(8)))
+    df = to_pandas(ft.calculate_feature_matrix(entityset=es, features=features, instance_ids=range(8)),
+                   index='id',
+                   sort_index=True)
     true = [False, True, True, False, False, False, False, False]
     v = df[isin.get_name()].values.tolist()
     assert true == v


### PR DESCRIPTION
Updated `Entity.query_by_values` to use a `merge` operation instead of an `isin` operation for Koalas to improve performance. This change also caused row ordering to be lost in some cases, so multiple tests were updated as a result.

This change reduced the time spent in the `query_by_values` function from 235 seconds to 4 seconds for the instacart predict-next-purchase problem.