### PR TITLE
Update primitive compatibility flags and get_function

### DIFF
--- a/featuretools/computational_backends/feature_set_calculator.py
+++ b/featuretools/computational_backends/feature_set_calculator.py
@@ -18,6 +18,7 @@ from featuretools.feature_base import (
 )
 from featuretools.utils import Trie
 from featuretools.utils.gen_utils import (
+    Lib,
     get_relationship_variable_id,
     import_or_none,
     is_instance
@@ -635,9 +636,9 @@ class FeatureSetCalculator(object):
                     if variable_id not in to_agg:
                         to_agg[variable_id] = []
                     if isinstance(base_frame, dd.DataFrame):
-                        func = f.get_function(agg_type='dask')
+                        func = f.get_function(agg_type=Lib.DASK)
                     elif is_instance(base_frame, ks, 'DataFrame'):
-                        func = f.get_function(agg_type='koalas')
+                        func = f.get_function(agg_type=Lib.KOALAS)
                     else:
                         func = f.get_function()
 

--- a/featuretools/computational_backends/feature_set_calculator.py
+++ b/featuretools/computational_backends/feature_set_calculator.py
@@ -634,8 +634,10 @@ class FeatureSetCalculator(object):
                     variable_id = f.base_features[0].get_name()
                     if variable_id not in to_agg:
                         to_agg[variable_id] = []
-                    if is_instance(base_frame, (dd, ks), 'DataFrame'):
-                        func = f.get_dask_aggregation()
+                    if isinstance(base_frame, dd.DataFrame):
+                        func = f.get_function(agg_type='dask')
+                    elif is_instance(base_frame, ks, 'DataFrame'):
+                        func = f.get_function(agg_type='koalas')
                     else:
                         func = f.get_function()
 

--- a/featuretools/computational_backends/feature_set_calculator.py
+++ b/featuretools/computational_backends/feature_set_calculator.py
@@ -18,7 +18,7 @@ from featuretools.feature_base import (
 )
 from featuretools.utils import Trie
 from featuretools.utils.gen_utils import (
-    Lib,
+    Library,
     get_relationship_variable_id,
     import_or_none,
     is_instance
@@ -636,9 +636,9 @@ class FeatureSetCalculator(object):
                     if variable_id not in to_agg:
                         to_agg[variable_id] = []
                     if isinstance(base_frame, dd.DataFrame):
-                        func = f.get_function(agg_type=Lib.DASK)
+                        func = f.get_function(agg_type=Library.DASK)
                     elif is_instance(base_frame, ks, 'DataFrame'):
-                        func = f.get_function(agg_type=Lib.KOALAS)
+                        func = f.get_function(agg_type=Library.KOALAS)
                     else:
                         func = f.get_function()
 

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -93,8 +93,8 @@ class FeatureBase(object):
                     self._names = [self.get_name() + '[{}]'.format(i) for i in range(len(self._names))]
         return self._names
 
-    def get_function(self):
-        return self.primitive.get_function()
+    def get_function(self, **kwargs):
+        return self.primitive.get_function(**kwargs)
 
     def get_dependencies(self, deep=False, ignored=None, copy=True):
         """Returns features that are used to calculate this feature
@@ -629,9 +629,6 @@ class AggregationFeature(FeatureBase):
             'where': self.where and self.where.unique_name(),
             'use_previous': self.use_previous and self.use_previous.get_arguments(),
         }
-
-    def get_dask_aggregation(self):
-        return self.primitive.get_dask_aggregation()
 
     def relationship_path_name(self):
         if self._path_is_unique:

--- a/featuretools/primitives/base/aggregation_primitive_base.py
+++ b/featuretools/primitives/base/aggregation_primitive_base.py
@@ -35,9 +35,6 @@ class AggregationPrimitive(PrimitiveBase):
                                        use_prev_str)
         return [base_name + "[%s]" % i for i in range(n)]
 
-    def get_dask_aggregation(self):
-        raise NotImplementedError("Subclass must implement")
-
 
 def make_agg_primitive(function, input_types, return_type, name=None,
                        stack_on_self=True, stack_on=None,

--- a/featuretools/primitives/base/aggregation_primitive_base.py
+++ b/featuretools/primitives/base/aggregation_primitive_base.py
@@ -4,7 +4,6 @@ import inspect
 
 from featuretools.primitives.base.primitive_base import PrimitiveBase
 from featuretools.primitives.base.utils import inspect_function_args
-from featuretools.utils.gen_utils import Library
 
 
 class AggregationPrimitive(PrimitiveBase):
@@ -35,11 +34,6 @@ class AggregationPrimitive(PrimitiveBase):
                                        where_str,
                                        use_prev_str)
         return [base_name + "[%s]" % i for i in range(n)]
-
-    def assert_compatible(self, agg_type):
-        if agg_type != Library.PANDAS and agg_type not in self.compatibility:
-            msg = '{} has not been implemented for {}'
-            raise NotImplementedError(msg.format(self.name, agg_type.value))
 
 
 def make_agg_primitive(function, input_types, return_type, name=None,

--- a/featuretools/primitives/base/aggregation_primitive_base.py
+++ b/featuretools/primitives/base/aggregation_primitive_base.py
@@ -4,6 +4,7 @@ import inspect
 
 from featuretools.primitives.base.primitive_base import PrimitiveBase
 from featuretools.primitives.base.utils import inspect_function_args
+from featuretools.utils.gen_utils import Library
 
 
 class AggregationPrimitive(PrimitiveBase):
@@ -34,6 +35,11 @@ class AggregationPrimitive(PrimitiveBase):
                                        where_str,
                                        use_prev_str)
         return [base_name + "[%s]" % i for i in range(n)]
+
+    def assert_compatible(self, agg_type):
+        if agg_type != Library.PANDAS and agg_type not in self.compatibility:
+            msg = '{} has not been implemented for {}'
+            raise NotImplementedError(msg.format(self.name, agg_type.value))
 
 
 def make_agg_primitive(function, input_types, return_type, name=None,

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -31,10 +31,8 @@ class PrimitiveBase(object):
     base_of_exclude = None
     # (bool) If True will only make one feature per unique set of base features
     commutative = False
-    # (bool) If True, is compatible with Dask EntitySets
-    dask_compatible = False
-    # (bool) If True, is compatible with Koalas EntitySets
-    koalas_compatible = False
+    #: (list): Additional compatible libraries
+    compatibility = []
 
     def __init__(self):
         pass

--- a/featuretools/primitives/base/primitive_base.py
+++ b/featuretools/primitives/base/primitive_base.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 from featuretools import config
 from featuretools.primitives.base.utils import signature
+from featuretools.utils.gen_utils import Library
 
 
 class PrimitiveBase(object):
@@ -32,7 +33,7 @@ class PrimitiveBase(object):
     # (bool) If True will only make one feature per unique set of base features
     commutative = False
     #: (list): Additional compatible libraries
-    compatibility = []
+    compatibility = [Library.PANDAS]
 
     def __init__(self):
         pass

--- a/featuretools/primitives/standard/aggregation_primitives.py
+++ b/featuretools/primitives/standard/aggregation_primitives.py
@@ -34,7 +34,7 @@ class Count(AggregationPrimitive):
     return_type = Numeric
     stack_on_self = False
     default_value = 0
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self, agg_type=Library.PANDAS):
         if agg_type in [Library.DASK, Library.KOALAS]:
@@ -62,7 +62,7 @@ class Sum(AggregationPrimitive):
     stack_on_self = False
     stack_on_exclude = [Count]
     default_value = 0
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self, agg_type=Library.PANDAS):
         if agg_type in [Library.DASK, Library.KOALAS]:
@@ -92,7 +92,7 @@ class Mean(AggregationPrimitive):
     name = "mean"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def __init__(self, skipna=True):
         self.skipna = skipna
@@ -147,7 +147,7 @@ class Min(AggregationPrimitive):
     input_types = [Numeric]
     return_type = Numeric
     stack_on_self = False
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self, agg_type=Library.PANDAS):
         if agg_type in [Library.DASK, Library.KOALAS]:
@@ -168,7 +168,7 @@ class Max(AggregationPrimitive):
     input_types = [Numeric]
     return_type = Numeric
     stack_on_self = False
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self, agg_type=Library.PANDAS):
         if agg_type in [Library.DASK, Library.KOALAS]:
@@ -194,7 +194,7 @@ class NumUnique(AggregationPrimitive):
     input_types = [Discrete]
     return_type = Numeric
     stack_on_self = False
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self, agg_type=Library.PANDAS):
         if agg_type == Library.DASK:
@@ -239,7 +239,7 @@ class NumTrue(AggregationPrimitive):
     default_value = 0
     stack_on = []
     stack_on_exclude = []
-    compatibility = [Library.DASK]
+    compatibility = [Library.PANDAS, Library.DASK]
 
     def get_function(self, agg_type=Library.PANDAS):
         if agg_type == Library.DASK:
@@ -277,7 +277,7 @@ class PercentTrue(AggregationPrimitive):
     stack_on = []
     stack_on_exclude = []
     default_value = 0
-    compatibility = [Library.DASK]
+    compatibility = [Library.PANDAS, Library.DASK]
 
     def get_function(self, agg_type=Library.PANDAS):
         if agg_type == Library.DASK:
@@ -464,7 +464,7 @@ class Std(AggregationPrimitive):
     input_types = [Numeric]
     return_type = Numeric
     stack_on_self = False
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self, agg_type=Library.PANDAS):
         if agg_type in [Library.DASK, Library.KOALAS]:
@@ -529,7 +529,7 @@ class Any(AggregationPrimitive):
     input_types = [Boolean]
     return_type = Boolean
     stack_on_self = False
-    compatibility = [Library.DASK]
+    compatibility = [Library.PANDAS, Library.DASK]
 
     def get_function(self, agg_type=Library.PANDAS):
         if agg_type == Library.DASK:
@@ -560,7 +560,7 @@ class All(AggregationPrimitive):
     input_types = [Boolean]
     return_type = Boolean
     stack_on_self = False
-    compatibility = [Library.DASK]
+    compatibility = [Library.PANDAS, Library.DASK]
 
     def get_function(self, agg_type=Library.PANDAS):
         if agg_type == Library.DASK:

--- a/featuretools/primitives/standard/aggregation_primitives.py
+++ b/featuretools/primitives/standard/aggregation_primitives.py
@@ -9,6 +9,7 @@ from featuretools.primitives.base.aggregation_primitive_base import (
     AggregationPrimitive
 )
 from featuretools.utils import convert_time_units
+from featuretools.utils.gen_utils import Lib
 from featuretools.variable_types import (
     Boolean,
     Categorical,
@@ -33,12 +34,12 @@ class Count(AggregationPrimitive):
     return_type = Numeric
     stack_on_self = False
     default_value = 0
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
-    def get_function(self, agg_type='pandas'):
-        if agg_type == 'pandas':
+    def get_function(self, agg_type=Lib.PANDAS):
+        if agg_type == Lib.PANDAS:
             return pd.Series.count
-        elif agg_type == 'dask' or agg_type == 'koalas':
+        if agg_type in [Lib.DASK, Lib.KOALAS]:
             return 'count'
 
     def generate_name(self, base_feature_names, relationship_path_name,
@@ -61,12 +62,12 @@ class Sum(AggregationPrimitive):
     stack_on_self = False
     stack_on_exclude = [Count]
     default_value = 0
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
-    def get_function(self, agg_type='pandas'):
-        if agg_type == 'pandas':
+    def get_function(self, agg_type=Lib.PANDAS):
+        if agg_type == Lib.PANDAS:
             return np.sum
-        elif agg_type == 'dask' or agg_type == 'koalas':
+        elif agg_type in [Lib.DASK, Lib.KOALAS]:
             return 'sum'
 
 
@@ -91,13 +92,13 @@ class Mean(AggregationPrimitive):
     name = "mean"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def __init__(self, skipna=True):
         self.skipna = skipna
 
-    def get_function(self, agg_type='pandas'):
-        if agg_type == 'pandas':
+    def get_function(self, agg_type=Lib.PANDAS):
+        if agg_type == Lib.PANDAS:
             if self.skipna:
                 # np.mean of series is functionally nanmean
                 return np.mean
@@ -106,8 +107,7 @@ class Mean(AggregationPrimitive):
                 return np.mean(series.values)
 
             return mean
-
-        elif agg_type == 'dask' or agg_type == 'koalas':
+        elif agg_type in [Lib.DASK, Lib.KOALAS]:
             return 'mean'
 
 
@@ -128,8 +128,8 @@ class Mode(AggregationPrimitive):
     input_types = [Discrete]
     return_type = None
 
-    def get_function(self, agg_type='pandas'):
-        if agg_type == 'pandas':
+    def get_function(self, agg_type=Lib.PANDAS):
+        if agg_type == Lib.PANDAS:
             def pd_mode(s):
                 return s.mode().get(0, np.nan)
 
@@ -148,12 +148,12 @@ class Min(AggregationPrimitive):
     input_types = [Numeric]
     return_type = Numeric
     stack_on_self = False
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
-    def get_function(self, agg_type='pandas'):
-        if agg_type == 'pandas':
+    def get_function(self, agg_type=Lib.PANDAS):
+        if agg_type == Lib.PANDAS:
             return np.min
-        elif agg_type == 'koalas' or agg_type == 'dask':
+        elif agg_type in [Lib.DASK, Lib.KOALAS]:
             return 'min'
 
 
@@ -169,12 +169,12 @@ class Max(AggregationPrimitive):
     input_types = [Numeric]
     return_type = Numeric
     stack_on_self = False
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
-    def get_function(self, agg_type='pandas'):
-        if agg_type == 'pandas':
+    def get_function(self, agg_type=Lib.PANDAS):
+        if agg_type == Lib.PANDAS:
             return np.max
-        elif agg_type == 'dask' or agg_type == 'koalas':
+        elif agg_type in [Lib.DASK, Lib.KOALAS]:
             return 'max'
 
 
@@ -195,13 +195,13 @@ class NumUnique(AggregationPrimitive):
     input_types = [Discrete]
     return_type = Numeric
     stack_on_self = False
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
-    def get_function(self, agg_type='pandas'):
-        if agg_type == 'pandas':
+    def get_function(self, agg_type=Lib.PANDAS):
+        if agg_type == Lib.PANDAS:
             return pd.Series.nunique
 
-        elif agg_type == 'dask':
+        elif agg_type == Lib.DASK:
             def chunk(s):
                 def inner_chunk(x):
                     x = x[:].dropna()
@@ -221,7 +221,7 @@ class NumUnique(AggregationPrimitive):
 
             return dd.Aggregation(self.name, chunk=chunk, agg=agg, finalize=finalize)
 
-        elif agg_type == 'koalas':
+        elif agg_type == Lib.KOALAS:
             return 'nunique'
 
 
@@ -243,13 +243,13 @@ class NumTrue(AggregationPrimitive):
     default_value = 0
     stack_on = []
     stack_on_exclude = []
-    compatibility = ['dask']
+    compatibility = [Lib.DASK]
 
-    def get_function(self, agg_type='pandas'):
-        if agg_type == 'pandas':
+    def get_function(self, agg_type=Lib.PANDAS):
+        if agg_type == Lib.PANDAS:
             return np.sum
 
-        elif agg_type == 'dask':
+        elif agg_type == Lib.DASK:
             def chunk(s):
                 chunk_sum = s.agg(np.sum)
                 if chunk_sum.dtype == 'bool':
@@ -282,15 +282,15 @@ class PercentTrue(AggregationPrimitive):
     stack_on = []
     stack_on_exclude = []
     default_value = 0
-    compatibility = ['dask']
+    compatibility = [Lib.DASK]
 
-    def get_function(self, agg_type='pandas'):
-        if agg_type == 'pandas':
+    def get_function(self, agg_type=Lib.PANDAS):
+        if agg_type == Lib.PANDAS:
             def percent_true(s):
                 return s.fillna(0).mean()
             return percent_true
 
-        elif agg_type == 'dask':
+        elif agg_type == Lib.DASK:
             def chunk(s):
                 def format_chunk(x):
                     return x[:].fillna(0)
@@ -339,8 +339,8 @@ class NMostCommon(AggregationPrimitive):
         self.n = n
         self.number_output_features = n
 
-    def get_function(self, agg_type='pandas'):
-        if agg_type == 'pandas':
+    def get_function(self, agg_type=Lib.PANDAS):
+        if agg_type == Lib.PANDAS:
             def n_most_common(x):
                 array = np.array(x.value_counts().index[:self.n])
                 if len(array) < self.n:
@@ -383,8 +383,8 @@ class AvgTimeBetween(AggregationPrimitive):
     def __init__(self, unit="seconds"):
         self.unit = unit.lower()
 
-    def get_function(self, agg_type='pandas'):
-        if agg_type == 'pandas':
+    def get_function(self, agg_type=Lib.PANDAS):
+        if agg_type == Lib.PANDAS:
             def pd_avg_time_between(x):
                 """Assumes time scales are closer to order
                 of seconds than to nanoseconds
@@ -432,8 +432,8 @@ class Median(AggregationPrimitive):
     input_types = [Numeric]
     return_type = Numeric
 
-    def get_function(self, agg_type='pandas'):
-        if agg_type == 'pandas':
+    def get_function(self, agg_type=Lib.PANDAS):
+        if agg_type == Lib.PANDAS:
             return pd.Series.median
 
 
@@ -456,8 +456,8 @@ class Skew(AggregationPrimitive):
     stack_on = []
     stack_on_self = False
 
-    def get_function(self, agg_type='pandas'):
-        if agg_type == 'pandas':
+    def get_function(self, agg_type=Lib.PANDAS):
+        if agg_type == Lib.PANDAS:
             return pd.Series.skew
 
 
@@ -473,12 +473,12 @@ class Std(AggregationPrimitive):
     input_types = [Numeric]
     return_type = Numeric
     stack_on_self = False
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
-    def get_function(self, agg_type='pandas'):
-        if agg_type == 'pandas':
+    def get_function(self, agg_type=Lib.PANDAS):
+        if agg_type == Lib.PANDAS:
             return np.std
-        elif agg_type == 'dask' or agg_type == 'koalas':
+        elif agg_type in [Lib.DASK, Lib.KOALAS]:
             return 'std'
 
 
@@ -495,8 +495,8 @@ class First(AggregationPrimitive):
     return_type = None
     stack_on_self = False
 
-    def get_function(self, agg_type='pandas'):
-        if agg_type == 'pandas':
+    def get_function(self, agg_type=Lib.PANDAS):
+        if agg_type == Lib.PANDAS:
             def pd_first(x):
                 return x.iloc[0]
 
@@ -516,8 +516,8 @@ class Last(AggregationPrimitive):
     return_type = None
     stack_on_self = False
 
-    def get_function(self, agg_type='pandas'):
-        if agg_type == 'pandas':
+    def get_function(self, agg_type=Lib.PANDAS):
+        if agg_type == Lib.PANDAS:
             def pd_last(x):
                 return x.iloc[-1]
 
@@ -540,13 +540,13 @@ class Any(AggregationPrimitive):
     input_types = [Boolean]
     return_type = Boolean
     stack_on_self = False
-    compatibility = ['dask']
+    compatibility = [Lib.DASK]
 
-    def get_function(self, agg_type='pandas'):
-        if agg_type == 'pandas':
+    def get_function(self, agg_type=Lib.PANDAS):
+        if agg_type == Lib.PANDAS:
             return np.any
 
-        elif agg_type == 'dask':
+        elif agg_type == Lib.DASK:
             def chunk(s):
                 return s.agg(np.any)
 
@@ -572,13 +572,13 @@ class All(AggregationPrimitive):
     input_types = [Boolean]
     return_type = Boolean
     stack_on_self = False
-    compatibility = ['dask']
+    compatibility = [Lib.DASK]
 
-    def get_function(self, agg_type='pandas'):
-        if agg_type == 'pandas':
+    def get_function(self, agg_type=Lib.PANDAS):
+        if agg_type == Lib.PANDAS:
             return np.all
 
-        elif agg_type == 'dask':
+        elif agg_type == Lib.DASK:
             def chunk(s):
                 return s.agg(np.all)
 
@@ -629,8 +629,8 @@ class TimeSinceLast(AggregationPrimitive):
     def __init__(self, unit="seconds"):
         self.unit = unit.lower()
 
-    def get_function(self, agg_type='pandas'):
-        if agg_type == 'pandas':
+    def get_function(self, agg_type=Lib.PANDAS):
+        if agg_type == Lib.PANDAS:
             def time_since_last(values, time=None):
                 time_since = time - values.iloc[-1]
                 return convert_time_units(time_since.total_seconds(), self.unit)
@@ -679,8 +679,8 @@ class TimeSinceFirst(AggregationPrimitive):
     def __init__(self, unit="seconds"):
         self.unit = unit.lower()
 
-    def get_function(self, agg_type='pandas'):
-        if agg_type == 'pandas':
+    def get_function(self, agg_type=Lib.PANDAS):
+        if agg_type == Lib.PANDAS:
             def time_since_first(values, time=None):
                 time_since = time - values.iloc[0]
                 return convert_time_units(time_since.total_seconds(), self.unit)
@@ -711,8 +711,8 @@ class Trend(AggregationPrimitive):
     input_types = [Numeric, DatetimeTimeIndex]
     return_type = Numeric
 
-    def get_function(self, agg_type='pandas'):
-        if agg_type == 'pandas':
+    def get_function(self, agg_type=Lib.PANDAS):
+        if agg_type == Lib.PANDAS:
             def pd_trend(y, x):
                 df = pd.DataFrame({"x": x, "y": y}).dropna()
                 if df.shape[0] <= 2:
@@ -799,8 +799,8 @@ class Entropy(AggregationPrimitive):
         self.dropna = dropna
         self.base = base
 
-    def get_function(self, agg_type='pandas'):
-        if agg_type == 'pandas':
+    def get_function(self, agg_type=Lib.PANDAS):
+        if agg_type == Lib.PANDAS:
             def pd_entropy(s):
                 distribution = s.value_counts(normalize=True, dropna=self.dropna)
                 return stats.entropy(distribution, base=self.base)

--- a/featuretools/primitives/standard/aggregation_primitives.py
+++ b/featuretools/primitives/standard/aggregation_primitives.py
@@ -106,7 +106,7 @@ class Mean(AggregationPrimitive):
 
         if self.skipna:
             # np.mean of series is functionally nanmean
-            return np.meangit
+            return np.mean
 
         def mean(series):
             return np.mean(series.values)

--- a/featuretools/primitives/standard/binary_transform.py
+++ b/featuretools/primitives/standard/binary_transform.py
@@ -30,7 +30,7 @@ class GreaterThan(TransformPrimitive):
     name = "greater_than"
     input_types = [[Numeric, Numeric], [Datetime, Datetime], [Ordinal, Ordinal]]
     return_type = Boolean
-    compatibility = [Library.DASK]
+    compatibility = [Library.PANDAS, Library.DASK]
 
     def get_function(self):
         return np.greater
@@ -55,7 +55,7 @@ class GreaterThanScalar(TransformPrimitive):
     name = "greater_than_scalar"
     input_types = [[Numeric], [Datetime], [Ordinal]]
     return_type = Boolean
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def __init__(self, value=0):
         self.value = value
@@ -85,7 +85,7 @@ class GreaterThanEqualTo(TransformPrimitive):
     name = "greater_than_equal_to"
     input_types = [[Numeric, Numeric], [Datetime, Datetime], [Ordinal, Ordinal]]
     return_type = Boolean
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self):
         return np.greater_equal
@@ -110,7 +110,7 @@ class GreaterThanEqualToScalar(TransformPrimitive):
     name = "greater_than_equal_to_scalar"
     input_types = [[Numeric], [Datetime], [Ordinal]]
     return_type = Boolean
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def __init__(self, value=0):
         self.value = value
@@ -140,7 +140,7 @@ class LessThan(TransformPrimitive):
     name = "less_than"
     input_types = [[Numeric, Numeric], [Datetime, Datetime], [Ordinal, Ordinal]]
     return_type = Boolean
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self):
         return np.less
@@ -165,7 +165,7 @@ class LessThanScalar(TransformPrimitive):
     name = "less_than_scalar"
     input_types = [[Numeric], [Datetime], [Ordinal]]
     return_type = Boolean
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def __init__(self, value=0):
         self.value = value
@@ -195,7 +195,7 @@ class LessThanEqualTo(TransformPrimitive):
     name = "less_than_equal_to"
     input_types = [[Numeric, Numeric], [Datetime, Datetime], [Ordinal, Ordinal]]
     return_type = Boolean
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self):
         return np.less_equal
@@ -220,7 +220,7 @@ class LessThanEqualToScalar(TransformPrimitive):
     name = "less_than_equal_to_scalar"
     input_types = [[Numeric], [Datetime], [Ordinal]]
     return_type = Boolean
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def __init__(self, value=0):
         self.value = value
@@ -251,7 +251,7 @@ class Equal(TransformPrimitive):
     input_types = [Variable, Variable]
     return_type = Boolean
     commutative = True
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def equal(x_vals, y_vals):
@@ -283,7 +283,7 @@ class EqualScalar(TransformPrimitive):
     name = "equal_scalar"
     input_types = [Variable]
     return_type = Boolean
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def __init__(self, value=None):
         self.value = value
@@ -314,7 +314,7 @@ class NotEqual(TransformPrimitive):
     input_types = [Variable, Variable]
     return_type = Boolean
     commutative = True
-    compatibility = [Library.DASK]
+    compatibility = [Library.PANDAS, Library.DASK]
 
     def get_function(self):
         def not_equal(x_vals, y_vals):
@@ -346,7 +346,7 @@ class NotEqualScalar(TransformPrimitive):
     name = "not_equal_scalar"
     input_types = [Variable]
     return_type = Boolean
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def __init__(self, value=None):
         self.value = value
@@ -377,7 +377,7 @@ class AddNumeric(TransformPrimitive):
     input_types = [Numeric, Numeric]
     return_type = Numeric
     commutative = True
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self):
         return np.add
@@ -401,7 +401,7 @@ class AddNumericScalar(TransformPrimitive):
     name = "add_numeric_scalar"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def __init__(self, value=0):
         self.value = value
@@ -436,7 +436,7 @@ class SubtractNumeric(TransformPrimitive):
     name = "subtract_numeric"
     input_types = [Numeric, Numeric]
     return_type = Numeric
-    compatibility = [Library.DASK]
+    compatibility = [Library.PANDAS, Library.DASK]
 
     def __init__(self, commutative=True):
         self.commutative = commutative
@@ -463,7 +463,7 @@ class SubtractNumericScalar(TransformPrimitive):
     name = "subtract_numeric_scalar"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def __init__(self, value=0):
         self.value = value
@@ -493,7 +493,7 @@ class ScalarSubtractNumericFeature(TransformPrimitive):
     name = "scalar_subtract_numeric_feature"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def __init__(self, value=0):
         self.value = value
@@ -528,7 +528,7 @@ class MultiplyNumeric(TransformPrimitive):
     ]
     return_type = Numeric
     commutative = True
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self):
         return np.multiply
@@ -552,7 +552,7 @@ class MultiplyNumericScalar(TransformPrimitive):
     name = "multiply_numeric_scalar"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def __init__(self, value=1):
         self.value = value
@@ -584,7 +584,7 @@ class MultiplyBoolean(TransformPrimitive):
 
     return_type = Boolean
     commutative = True
-    compatibility = [Library.DASK]
+    compatibility = [Library.PANDAS, Library.DASK]
 
     def get_function(self):
         return np.bitwise_and
@@ -614,7 +614,7 @@ class DivideNumeric(TransformPrimitive):
     name = "divide_numeric"
     input_types = [Numeric, Numeric]
     return_type = Numeric
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def __init__(self, commutative=False):
         self.commutative = commutative
@@ -641,7 +641,7 @@ class DivideNumericScalar(TransformPrimitive):
     name = "divide_numeric_scalar"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def __init__(self, value=1):
         self.value = value
@@ -671,7 +671,7 @@ class DivideByFeature(TransformPrimitive):
     name = "divide_by_feature"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def __init__(self, value=1):
         self.value = value
@@ -701,7 +701,7 @@ class ModuloNumeric(TransformPrimitive):
     name = "modulo_numeric"
     input_types = [Numeric, Numeric]
     return_type = Numeric
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self):
         return np.mod
@@ -726,7 +726,7 @@ class ModuloNumericScalar(TransformPrimitive):
     name = "modulo_numeric_scalar"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def __init__(self, value=1):
         self.value = value
@@ -756,7 +756,7 @@ class ModuloByFeature(TransformPrimitive):
     name = "modulo_by_feature"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def __init__(self, value=1):
         self.value = value
@@ -787,7 +787,7 @@ class And(TransformPrimitive):
     input_types = [Boolean, Boolean]
     return_type = Boolean
     commutative = True
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self):
         return np.logical_and
@@ -813,7 +813,7 @@ class Or(TransformPrimitive):
     input_types = [Boolean, Boolean]
     return_type = Boolean
     commutative = True
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self):
         return np.logical_or

--- a/featuretools/primitives/standard/binary_transform.py
+++ b/featuretools/primitives/standard/binary_transform.py
@@ -4,7 +4,7 @@ import pandas as pd
 from featuretools.primitives.base.transform_primitive_base import (
     TransformPrimitive
 )
-from featuretools.utils.gen_utils import Lib
+from featuretools.utils.gen_utils import Library
 from featuretools.variable_types import (
     Boolean,
     Datetime,
@@ -30,7 +30,7 @@ class GreaterThan(TransformPrimitive):
     name = "greater_than"
     input_types = [[Numeric, Numeric], [Datetime, Datetime], [Ordinal, Ordinal]]
     return_type = Boolean
-    compatibility = [Lib.DASK]
+    compatibility = [Library.DASK]
 
     def get_function(self):
         return np.greater
@@ -55,7 +55,7 @@ class GreaterThanScalar(TransformPrimitive):
     name = "greater_than_scalar"
     input_types = [[Numeric], [Datetime], [Ordinal]]
     return_type = Boolean
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def __init__(self, value=0):
         self.value = value
@@ -85,7 +85,7 @@ class GreaterThanEqualTo(TransformPrimitive):
     name = "greater_than_equal_to"
     input_types = [[Numeric, Numeric], [Datetime, Datetime], [Ordinal, Ordinal]]
     return_type = Boolean
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def get_function(self):
         return np.greater_equal
@@ -110,7 +110,7 @@ class GreaterThanEqualToScalar(TransformPrimitive):
     name = "greater_than_equal_to_scalar"
     input_types = [[Numeric], [Datetime], [Ordinal]]
     return_type = Boolean
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def __init__(self, value=0):
         self.value = value
@@ -140,7 +140,7 @@ class LessThan(TransformPrimitive):
     name = "less_than"
     input_types = [[Numeric, Numeric], [Datetime, Datetime], [Ordinal, Ordinal]]
     return_type = Boolean
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def get_function(self):
         return np.less
@@ -165,7 +165,7 @@ class LessThanScalar(TransformPrimitive):
     name = "less_than_scalar"
     input_types = [[Numeric], [Datetime], [Ordinal]]
     return_type = Boolean
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def __init__(self, value=0):
         self.value = value
@@ -195,7 +195,7 @@ class LessThanEqualTo(TransformPrimitive):
     name = "less_than_equal_to"
     input_types = [[Numeric, Numeric], [Datetime, Datetime], [Ordinal, Ordinal]]
     return_type = Boolean
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def get_function(self):
         return np.less_equal
@@ -220,7 +220,7 @@ class LessThanEqualToScalar(TransformPrimitive):
     name = "less_than_equal_to_scalar"
     input_types = [[Numeric], [Datetime], [Ordinal]]
     return_type = Boolean
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def __init__(self, value=0):
         self.value = value
@@ -251,7 +251,7 @@ class Equal(TransformPrimitive):
     input_types = [Variable, Variable]
     return_type = Boolean
     commutative = True
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def equal(x_vals, y_vals):
@@ -283,7 +283,7 @@ class EqualScalar(TransformPrimitive):
     name = "equal_scalar"
     input_types = [Variable]
     return_type = Boolean
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def __init__(self, value=None):
         self.value = value
@@ -314,7 +314,7 @@ class NotEqual(TransformPrimitive):
     input_types = [Variable, Variable]
     return_type = Boolean
     commutative = True
-    compatibility = [Lib.DASK]
+    compatibility = [Library.DASK]
 
     def get_function(self):
         def not_equal(x_vals, y_vals):
@@ -346,7 +346,7 @@ class NotEqualScalar(TransformPrimitive):
     name = "not_equal_scalar"
     input_types = [Variable]
     return_type = Boolean
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def __init__(self, value=None):
         self.value = value
@@ -377,7 +377,7 @@ class AddNumeric(TransformPrimitive):
     input_types = [Numeric, Numeric]
     return_type = Numeric
     commutative = True
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def get_function(self):
         return np.add
@@ -401,7 +401,7 @@ class AddNumericScalar(TransformPrimitive):
     name = "add_numeric_scalar"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def __init__(self, value=0):
         self.value = value
@@ -436,7 +436,7 @@ class SubtractNumeric(TransformPrimitive):
     name = "subtract_numeric"
     input_types = [Numeric, Numeric]
     return_type = Numeric
-    compatibility = [Lib.DASK]
+    compatibility = [Library.DASK]
 
     def __init__(self, commutative=True):
         self.commutative = commutative
@@ -463,7 +463,7 @@ class SubtractNumericScalar(TransformPrimitive):
     name = "subtract_numeric_scalar"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def __init__(self, value=0):
         self.value = value
@@ -493,7 +493,7 @@ class ScalarSubtractNumericFeature(TransformPrimitive):
     name = "scalar_subtract_numeric_feature"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def __init__(self, value=0):
         self.value = value
@@ -528,7 +528,7 @@ class MultiplyNumeric(TransformPrimitive):
     ]
     return_type = Numeric
     commutative = True
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def get_function(self):
         return np.multiply
@@ -552,7 +552,7 @@ class MultiplyNumericScalar(TransformPrimitive):
     name = "multiply_numeric_scalar"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def __init__(self, value=1):
         self.value = value
@@ -584,7 +584,7 @@ class MultiplyBoolean(TransformPrimitive):
 
     return_type = Boolean
     commutative = True
-    compatibility = [Lib.DASK]
+    compatibility = [Library.DASK]
 
     def get_function(self):
         return np.bitwise_and
@@ -614,7 +614,7 @@ class DivideNumeric(TransformPrimitive):
     name = "divide_numeric"
     input_types = [Numeric, Numeric]
     return_type = Numeric
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def __init__(self, commutative=False):
         self.commutative = commutative
@@ -641,7 +641,7 @@ class DivideNumericScalar(TransformPrimitive):
     name = "divide_numeric_scalar"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def __init__(self, value=1):
         self.value = value
@@ -671,7 +671,7 @@ class DivideByFeature(TransformPrimitive):
     name = "divide_by_feature"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def __init__(self, value=1):
         self.value = value
@@ -701,7 +701,7 @@ class ModuloNumeric(TransformPrimitive):
     name = "modulo_numeric"
     input_types = [Numeric, Numeric]
     return_type = Numeric
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def get_function(self):
         return np.mod
@@ -726,7 +726,7 @@ class ModuloNumericScalar(TransformPrimitive):
     name = "modulo_numeric_scalar"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def __init__(self, value=1):
         self.value = value
@@ -756,7 +756,7 @@ class ModuloByFeature(TransformPrimitive):
     name = "modulo_by_feature"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def __init__(self, value=1):
         self.value = value
@@ -787,7 +787,7 @@ class And(TransformPrimitive):
     input_types = [Boolean, Boolean]
     return_type = Boolean
     commutative = True
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def get_function(self):
         return np.logical_and
@@ -813,7 +813,7 @@ class Or(TransformPrimitive):
     input_types = [Boolean, Boolean]
     return_type = Boolean
     commutative = True
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def get_function(self):
         return np.logical_or

--- a/featuretools/primitives/standard/binary_transform.py
+++ b/featuretools/primitives/standard/binary_transform.py
@@ -4,6 +4,7 @@ import pandas as pd
 from featuretools.primitives.base.transform_primitive_base import (
     TransformPrimitive
 )
+from featuretools.utils.gen_utils import Lib
 from featuretools.variable_types import (
     Boolean,
     Datetime,
@@ -29,7 +30,7 @@ class GreaterThan(TransformPrimitive):
     name = "greater_than"
     input_types = [[Numeric, Numeric], [Datetime, Datetime], [Ordinal, Ordinal]]
     return_type = Boolean
-    compatibility = ['dask']
+    compatibility = [Lib.DASK]
 
     def get_function(self):
         return np.greater
@@ -54,7 +55,7 @@ class GreaterThanScalar(TransformPrimitive):
     name = "greater_than_scalar"
     input_types = [[Numeric], [Datetime], [Ordinal]]
     return_type = Boolean
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def __init__(self, value=0):
         self.value = value
@@ -84,7 +85,7 @@ class GreaterThanEqualTo(TransformPrimitive):
     name = "greater_than_equal_to"
     input_types = [[Numeric, Numeric], [Datetime, Datetime], [Ordinal, Ordinal]]
     return_type = Boolean
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def get_function(self):
         return np.greater_equal
@@ -109,7 +110,7 @@ class GreaterThanEqualToScalar(TransformPrimitive):
     name = "greater_than_equal_to_scalar"
     input_types = [[Numeric], [Datetime], [Ordinal]]
     return_type = Boolean
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def __init__(self, value=0):
         self.value = value
@@ -139,7 +140,7 @@ class LessThan(TransformPrimitive):
     name = "less_than"
     input_types = [[Numeric, Numeric], [Datetime, Datetime], [Ordinal, Ordinal]]
     return_type = Boolean
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def get_function(self):
         return np.less
@@ -164,7 +165,7 @@ class LessThanScalar(TransformPrimitive):
     name = "less_than_scalar"
     input_types = [[Numeric], [Datetime], [Ordinal]]
     return_type = Boolean
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def __init__(self, value=0):
         self.value = value
@@ -194,7 +195,7 @@ class LessThanEqualTo(TransformPrimitive):
     name = "less_than_equal_to"
     input_types = [[Numeric, Numeric], [Datetime, Datetime], [Ordinal, Ordinal]]
     return_type = Boolean
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def get_function(self):
         return np.less_equal
@@ -219,7 +220,7 @@ class LessThanEqualToScalar(TransformPrimitive):
     name = "less_than_equal_to_scalar"
     input_types = [[Numeric], [Datetime], [Ordinal]]
     return_type = Boolean
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def __init__(self, value=0):
         self.value = value
@@ -250,7 +251,7 @@ class Equal(TransformPrimitive):
     input_types = [Variable, Variable]
     return_type = Boolean
     commutative = True
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def get_function(self):
         def equal(x_vals, y_vals):
@@ -282,7 +283,7 @@ class EqualScalar(TransformPrimitive):
     name = "equal_scalar"
     input_types = [Variable]
     return_type = Boolean
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def __init__(self, value=None):
         self.value = value
@@ -313,7 +314,7 @@ class NotEqual(TransformPrimitive):
     input_types = [Variable, Variable]
     return_type = Boolean
     commutative = True
-    compatibility = ['dask']
+    compatibility = [Lib.DASK]
 
     def get_function(self):
         def not_equal(x_vals, y_vals):
@@ -345,7 +346,7 @@ class NotEqualScalar(TransformPrimitive):
     name = "not_equal_scalar"
     input_types = [Variable]
     return_type = Boolean
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def __init__(self, value=None):
         self.value = value
@@ -376,7 +377,7 @@ class AddNumeric(TransformPrimitive):
     input_types = [Numeric, Numeric]
     return_type = Numeric
     commutative = True
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def get_function(self):
         return np.add
@@ -400,7 +401,7 @@ class AddNumericScalar(TransformPrimitive):
     name = "add_numeric_scalar"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def __init__(self, value=0):
         self.value = value
@@ -435,7 +436,7 @@ class SubtractNumeric(TransformPrimitive):
     name = "subtract_numeric"
     input_types = [Numeric, Numeric]
     return_type = Numeric
-    compatibility = ['dask']
+    compatibility = [Lib.DASK]
 
     def __init__(self, commutative=True):
         self.commutative = commutative
@@ -462,7 +463,7 @@ class SubtractNumericScalar(TransformPrimitive):
     name = "subtract_numeric_scalar"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def __init__(self, value=0):
         self.value = value
@@ -492,7 +493,7 @@ class ScalarSubtractNumericFeature(TransformPrimitive):
     name = "scalar_subtract_numeric_feature"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def __init__(self, value=0):
         self.value = value
@@ -527,7 +528,7 @@ class MultiplyNumeric(TransformPrimitive):
     ]
     return_type = Numeric
     commutative = True
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def get_function(self):
         return np.multiply
@@ -551,7 +552,7 @@ class MultiplyNumericScalar(TransformPrimitive):
     name = "multiply_numeric_scalar"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def __init__(self, value=1):
         self.value = value
@@ -583,7 +584,7 @@ class MultiplyBoolean(TransformPrimitive):
 
     return_type = Boolean
     commutative = True
-    compatibility = ['dask']
+    compatibility = [Lib.DASK]
 
     def get_function(self):
         return np.bitwise_and
@@ -613,7 +614,7 @@ class DivideNumeric(TransformPrimitive):
     name = "divide_numeric"
     input_types = [Numeric, Numeric]
     return_type = Numeric
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def __init__(self, commutative=False):
         self.commutative = commutative
@@ -640,7 +641,7 @@ class DivideNumericScalar(TransformPrimitive):
     name = "divide_numeric_scalar"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def __init__(self, value=1):
         self.value = value
@@ -670,7 +671,7 @@ class DivideByFeature(TransformPrimitive):
     name = "divide_by_feature"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def __init__(self, value=1):
         self.value = value
@@ -700,7 +701,7 @@ class ModuloNumeric(TransformPrimitive):
     name = "modulo_numeric"
     input_types = [Numeric, Numeric]
     return_type = Numeric
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def get_function(self):
         return np.mod
@@ -725,7 +726,7 @@ class ModuloNumericScalar(TransformPrimitive):
     name = "modulo_numeric_scalar"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def __init__(self, value=1):
         self.value = value
@@ -755,7 +756,7 @@ class ModuloByFeature(TransformPrimitive):
     name = "modulo_by_feature"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def __init__(self, value=1):
         self.value = value
@@ -786,7 +787,7 @@ class And(TransformPrimitive):
     input_types = [Boolean, Boolean]
     return_type = Boolean
     commutative = True
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def get_function(self):
         return np.logical_and
@@ -812,7 +813,7 @@ class Or(TransformPrimitive):
     input_types = [Boolean, Boolean]
     return_type = Boolean
     commutative = True
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def get_function(self):
         return np.logical_or

--- a/featuretools/primitives/standard/binary_transform.py
+++ b/featuretools/primitives/standard/binary_transform.py
@@ -29,7 +29,7 @@ class GreaterThan(TransformPrimitive):
     name = "greater_than"
     input_types = [[Numeric, Numeric], [Datetime, Datetime], [Ordinal, Ordinal]]
     return_type = Boolean
-    dask_compatible = True
+    compatibility = ['dask']
 
     def get_function(self):
         return np.greater
@@ -54,8 +54,7 @@ class GreaterThanScalar(TransformPrimitive):
     name = "greater_than_scalar"
     input_types = [[Numeric], [Datetime], [Ordinal]]
     return_type = Boolean
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def __init__(self, value=0):
         self.value = value
@@ -85,8 +84,7 @@ class GreaterThanEqualTo(TransformPrimitive):
     name = "greater_than_equal_to"
     input_types = [[Numeric, Numeric], [Datetime, Datetime], [Ordinal, Ordinal]]
     return_type = Boolean
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def get_function(self):
         return np.greater_equal
@@ -111,8 +109,7 @@ class GreaterThanEqualToScalar(TransformPrimitive):
     name = "greater_than_equal_to_scalar"
     input_types = [[Numeric], [Datetime], [Ordinal]]
     return_type = Boolean
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def __init__(self, value=0):
         self.value = value
@@ -142,8 +139,7 @@ class LessThan(TransformPrimitive):
     name = "less_than"
     input_types = [[Numeric, Numeric], [Datetime, Datetime], [Ordinal, Ordinal]]
     return_type = Boolean
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def get_function(self):
         return np.less
@@ -168,8 +164,7 @@ class LessThanScalar(TransformPrimitive):
     name = "less_than_scalar"
     input_types = [[Numeric], [Datetime], [Ordinal]]
     return_type = Boolean
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def __init__(self, value=0):
         self.value = value
@@ -199,8 +194,7 @@ class LessThanEqualTo(TransformPrimitive):
     name = "less_than_equal_to"
     input_types = [[Numeric, Numeric], [Datetime, Datetime], [Ordinal, Ordinal]]
     return_type = Boolean
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def get_function(self):
         return np.less_equal
@@ -225,8 +219,7 @@ class LessThanEqualToScalar(TransformPrimitive):
     name = "less_than_equal_to_scalar"
     input_types = [[Numeric], [Datetime], [Ordinal]]
     return_type = Boolean
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def __init__(self, value=0):
         self.value = value
@@ -257,8 +250,7 @@ class Equal(TransformPrimitive):
     input_types = [Variable, Variable]
     return_type = Boolean
     commutative = True
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def get_function(self):
         def equal(x_vals, y_vals):
@@ -290,8 +282,7 @@ class EqualScalar(TransformPrimitive):
     name = "equal_scalar"
     input_types = [Variable]
     return_type = Boolean
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def __init__(self, value=None):
         self.value = value
@@ -322,7 +313,7 @@ class NotEqual(TransformPrimitive):
     input_types = [Variable, Variable]
     return_type = Boolean
     commutative = True
-    dask_compatible = True
+    compatibility = ['dask']
 
     def get_function(self):
         def not_equal(x_vals, y_vals):
@@ -354,8 +345,7 @@ class NotEqualScalar(TransformPrimitive):
     name = "not_equal_scalar"
     input_types = [Variable]
     return_type = Boolean
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def __init__(self, value=None):
         self.value = value
@@ -386,8 +376,7 @@ class AddNumeric(TransformPrimitive):
     input_types = [Numeric, Numeric]
     return_type = Numeric
     commutative = True
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def get_function(self):
         return np.add
@@ -411,8 +400,7 @@ class AddNumericScalar(TransformPrimitive):
     name = "add_numeric_scalar"
     input_types = [Numeric]
     return_type = Numeric
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def __init__(self, value=0):
         self.value = value
@@ -447,7 +435,7 @@ class SubtractNumeric(TransformPrimitive):
     name = "subtract_numeric"
     input_types = [Numeric, Numeric]
     return_type = Numeric
-    dask_compatible = True
+    compatibility = ['dask']
 
     def __init__(self, commutative=True):
         self.commutative = commutative
@@ -474,8 +462,7 @@ class SubtractNumericScalar(TransformPrimitive):
     name = "subtract_numeric_scalar"
     input_types = [Numeric]
     return_type = Numeric
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def __init__(self, value=0):
         self.value = value
@@ -505,8 +492,7 @@ class ScalarSubtractNumericFeature(TransformPrimitive):
     name = "scalar_subtract_numeric_feature"
     input_types = [Numeric]
     return_type = Numeric
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def __init__(self, value=0):
         self.value = value
@@ -541,8 +527,7 @@ class MultiplyNumeric(TransformPrimitive):
     ]
     return_type = Numeric
     commutative = True
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def get_function(self):
         return np.multiply
@@ -566,8 +551,7 @@ class MultiplyNumericScalar(TransformPrimitive):
     name = "multiply_numeric_scalar"
     input_types = [Numeric]
     return_type = Numeric
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def __init__(self, value=1):
         self.value = value
@@ -599,7 +583,7 @@ class MultiplyBoolean(TransformPrimitive):
 
     return_type = Boolean
     commutative = True
-    dask_compatible = True
+    compatibility = ['dask']
 
     def get_function(self):
         return np.bitwise_and
@@ -629,8 +613,7 @@ class DivideNumeric(TransformPrimitive):
     name = "divide_numeric"
     input_types = [Numeric, Numeric]
     return_type = Numeric
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def __init__(self, commutative=False):
         self.commutative = commutative
@@ -657,8 +640,7 @@ class DivideNumericScalar(TransformPrimitive):
     name = "divide_numeric_scalar"
     input_types = [Numeric]
     return_type = Numeric
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def __init__(self, value=1):
         self.value = value
@@ -688,8 +670,7 @@ class DivideByFeature(TransformPrimitive):
     name = "divide_by_feature"
     input_types = [Numeric]
     return_type = Numeric
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def __init__(self, value=1):
         self.value = value
@@ -719,8 +700,7 @@ class ModuloNumeric(TransformPrimitive):
     name = "modulo_numeric"
     input_types = [Numeric, Numeric]
     return_type = Numeric
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def get_function(self):
         return np.mod
@@ -745,8 +725,7 @@ class ModuloNumericScalar(TransformPrimitive):
     name = "modulo_numeric_scalar"
     input_types = [Numeric]
     return_type = Numeric
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def __init__(self, value=1):
         self.value = value
@@ -776,8 +755,7 @@ class ModuloByFeature(TransformPrimitive):
     name = "modulo_by_feature"
     input_types = [Numeric]
     return_type = Numeric
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def __init__(self, value=1):
         self.value = value
@@ -808,8 +786,7 @@ class And(TransformPrimitive):
     input_types = [Boolean, Boolean]
     return_type = Boolean
     commutative = True
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def get_function(self):
         return np.logical_and
@@ -835,8 +812,7 @@ class Or(TransformPrimitive):
     input_types = [Boolean, Boolean]
     return_type = Boolean
     commutative = True
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def get_function(self):
         return np.logical_or

--- a/featuretools/primitives/standard/transform_primitive.py
+++ b/featuretools/primitives/standard/transform_primitive.py
@@ -7,6 +7,7 @@ from featuretools.primitives.base.transform_primitive_base import (
 )
 from featuretools.utils import convert_time_units
 from featuretools.utils.entity_utils import replace_latlong_nan
+from featuretools.utils.gen_utils import Lib
 from featuretools.variable_types import (
     Boolean,
     DateOfBirth,
@@ -31,7 +32,7 @@ class IsNull(TransformPrimitive):
     name = "is_null"
     input_types = [Variable]
     return_type = Boolean
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def get_function(self):
         def isnull(array):
@@ -50,7 +51,7 @@ class Absolute(TransformPrimitive):
     name = "absolute"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def get_function(self):
         return np.absolute
@@ -108,7 +109,7 @@ class Day(TransformPrimitive):
     name = "day"
     input_types = [Datetime]
     return_type = Ordinal
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def get_function(self):
         def day(vals):
@@ -131,7 +132,7 @@ class Hour(TransformPrimitive):
     name = "hour"
     input_types = [Datetime]
     return_type = Ordinal
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def get_function(self):
         def hour(vals):
@@ -154,7 +155,7 @@ class Second(TransformPrimitive):
     name = "second"
     input_types = [Datetime]
     return_type = Numeric
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def get_function(self):
         def second(vals):
@@ -177,7 +178,7 @@ class Minute(TransformPrimitive):
     name = "minute"
     input_types = [Datetime]
     return_type = Numeric
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def get_function(self):
         def minute(vals):
@@ -205,7 +206,7 @@ class Week(TransformPrimitive):
     name = "week"
     input_types = [Datetime]
     return_type = Ordinal
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def get_function(self):
         def week(vals):
@@ -233,7 +234,7 @@ class Month(TransformPrimitive):
     name = "month"
     input_types = [Datetime]
     return_type = Ordinal
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def get_function(self):
         def month(vals):
@@ -256,7 +257,7 @@ class Year(TransformPrimitive):
     name = "year"
     input_types = [Datetime]
     return_type = Ordinal
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def get_function(self):
         def year(vals):
@@ -279,7 +280,7 @@ class IsWeekend(TransformPrimitive):
     name = "is_weekend"
     input_types = [Datetime]
     return_type = Boolean
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def get_function(self):
         def is_weekend(vals):
@@ -306,7 +307,7 @@ class Weekday(TransformPrimitive):
     name = "weekday"
     input_types = [Datetime]
     return_type = Ordinal
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def get_function(self):
         def weekday(vals):
@@ -327,7 +328,7 @@ class NumCharacters(TransformPrimitive):
     name = 'num_characters'
     input_types = [Text]
     return_type = Numeric
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def get_function(self):
         def character_counter(array):
@@ -349,7 +350,7 @@ class NumWords(TransformPrimitive):
     name = 'num_words'
     input_types = [Text]
     return_type = Numeric
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def get_function(self):
         def word_counter(array):
@@ -392,7 +393,7 @@ class TimeSince(TransformPrimitive):
     input_types = [Datetime]
     return_type = Numeric
     uses_calc_time = True
-    compatibility = ['dask']
+    compatibility = [Lib.DASK]
 
     def __init__(self, unit="seconds"):
         self.unit = unit.lower()
@@ -415,7 +416,7 @@ class IsIn(TransformPrimitive):
     name = "isin"
     input_types = [Variable]
     return_type = Boolean
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def __init__(self, list_of_outputs=None):
         self.list_of_outputs = list_of_outputs
@@ -468,7 +469,7 @@ class Negate(TransformPrimitive):
     name = "negate"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def get_function(self):
         def negate(vals):
@@ -490,7 +491,7 @@ class Not(TransformPrimitive):
     name = "not"
     input_types = [Boolean]
     return_type = Boolean
-    compatibility = ['dask', 'koalas']
+    compatibility = [Lib.DASK, Lib.KOALAS]
 
     def generate_name(self, base_feature_names):
         return u"NOT({})".format(base_feature_names[0])
@@ -658,7 +659,7 @@ class Age(TransformPrimitive):
     input_types = [DateOfBirth]
     return_type = Numeric
     uses_calc_time = True
-    compatibility = ['dask']
+    compatibility = [Lib.DASK]
 
     def get_function(self):
         def age(x, time=None):

--- a/featuretools/primitives/standard/transform_primitive.py
+++ b/featuretools/primitives/standard/transform_primitive.py
@@ -32,7 +32,7 @@ class IsNull(TransformPrimitive):
     name = "is_null"
     input_types = [Variable]
     return_type = Boolean
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def isnull(array):
@@ -51,7 +51,7 @@ class Absolute(TransformPrimitive):
     name = "absolute"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self):
         return np.absolute
@@ -109,7 +109,7 @@ class Day(TransformPrimitive):
     name = "day"
     input_types = [Datetime]
     return_type = Ordinal
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def day(vals):
@@ -132,7 +132,7 @@ class Hour(TransformPrimitive):
     name = "hour"
     input_types = [Datetime]
     return_type = Ordinal
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def hour(vals):
@@ -155,7 +155,7 @@ class Second(TransformPrimitive):
     name = "second"
     input_types = [Datetime]
     return_type = Numeric
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def second(vals):
@@ -178,7 +178,7 @@ class Minute(TransformPrimitive):
     name = "minute"
     input_types = [Datetime]
     return_type = Numeric
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def minute(vals):
@@ -206,7 +206,7 @@ class Week(TransformPrimitive):
     name = "week"
     input_types = [Datetime]
     return_type = Ordinal
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def week(vals):
@@ -234,7 +234,7 @@ class Month(TransformPrimitive):
     name = "month"
     input_types = [Datetime]
     return_type = Ordinal
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def month(vals):
@@ -257,7 +257,7 @@ class Year(TransformPrimitive):
     name = "year"
     input_types = [Datetime]
     return_type = Ordinal
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def year(vals):
@@ -280,7 +280,7 @@ class IsWeekend(TransformPrimitive):
     name = "is_weekend"
     input_types = [Datetime]
     return_type = Boolean
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def is_weekend(vals):
@@ -307,7 +307,7 @@ class Weekday(TransformPrimitive):
     name = "weekday"
     input_types = [Datetime]
     return_type = Ordinal
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def weekday(vals):
@@ -328,7 +328,7 @@ class NumCharacters(TransformPrimitive):
     name = 'num_characters'
     input_types = [Text]
     return_type = Numeric
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def character_counter(array):
@@ -350,7 +350,7 @@ class NumWords(TransformPrimitive):
     name = 'num_words'
     input_types = [Text]
     return_type = Numeric
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def word_counter(array):
@@ -393,7 +393,7 @@ class TimeSince(TransformPrimitive):
     input_types = [Datetime]
     return_type = Numeric
     uses_calc_time = True
-    compatibility = [Library.DASK]
+    compatibility = [Library.PANDAS, Library.DASK]
 
     def __init__(self, unit="seconds"):
         self.unit = unit.lower()
@@ -416,7 +416,7 @@ class IsIn(TransformPrimitive):
     name = "isin"
     input_types = [Variable]
     return_type = Boolean
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def __init__(self, list_of_outputs=None):
         self.list_of_outputs = list_of_outputs
@@ -469,7 +469,7 @@ class Negate(TransformPrimitive):
     name = "negate"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def negate(vals):
@@ -491,7 +491,7 @@ class Not(TransformPrimitive):
     name = "not"
     input_types = [Boolean]
     return_type = Boolean
-    compatibility = [Library.DASK, Library.KOALAS]
+    compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
     def generate_name(self, base_feature_names):
         return u"NOT({})".format(base_feature_names[0])
@@ -659,7 +659,7 @@ class Age(TransformPrimitive):
     input_types = [DateOfBirth]
     return_type = Numeric
     uses_calc_time = True
-    compatibility = [Library.DASK]
+    compatibility = [Library.PANDAS, Library.DASK]
 
     def get_function(self):
         def age(x, time=None):

--- a/featuretools/primitives/standard/transform_primitive.py
+++ b/featuretools/primitives/standard/transform_primitive.py
@@ -31,8 +31,7 @@ class IsNull(TransformPrimitive):
     name = "is_null"
     input_types = [Variable]
     return_type = Boolean
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def get_function(self):
         def isnull(array):
@@ -51,8 +50,7 @@ class Absolute(TransformPrimitive):
     name = "absolute"
     input_types = [Numeric]
     return_type = Numeric
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def get_function(self):
         return np.absolute
@@ -110,8 +108,7 @@ class Day(TransformPrimitive):
     name = "day"
     input_types = [Datetime]
     return_type = Ordinal
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def get_function(self):
         def day(vals):
@@ -134,8 +131,7 @@ class Hour(TransformPrimitive):
     name = "hour"
     input_types = [Datetime]
     return_type = Ordinal
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def get_function(self):
         def hour(vals):
@@ -158,8 +154,7 @@ class Second(TransformPrimitive):
     name = "second"
     input_types = [Datetime]
     return_type = Numeric
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def get_function(self):
         def second(vals):
@@ -182,8 +177,7 @@ class Minute(TransformPrimitive):
     name = "minute"
     input_types = [Datetime]
     return_type = Numeric
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def get_function(self):
         def minute(vals):
@@ -211,8 +205,7 @@ class Week(TransformPrimitive):
     name = "week"
     input_types = [Datetime]
     return_type = Ordinal
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def get_function(self):
         def week(vals):
@@ -240,8 +233,7 @@ class Month(TransformPrimitive):
     name = "month"
     input_types = [Datetime]
     return_type = Ordinal
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def get_function(self):
         def month(vals):
@@ -264,8 +256,7 @@ class Year(TransformPrimitive):
     name = "year"
     input_types = [Datetime]
     return_type = Ordinal
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def get_function(self):
         def year(vals):
@@ -288,8 +279,7 @@ class IsWeekend(TransformPrimitive):
     name = "is_weekend"
     input_types = [Datetime]
     return_type = Boolean
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def get_function(self):
         def is_weekend(vals):
@@ -316,8 +306,7 @@ class Weekday(TransformPrimitive):
     name = "weekday"
     input_types = [Datetime]
     return_type = Ordinal
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def get_function(self):
         def weekday(vals):
@@ -338,8 +327,7 @@ class NumCharacters(TransformPrimitive):
     name = 'num_characters'
     input_types = [Text]
     return_type = Numeric
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def get_function(self):
         def character_counter(array):
@@ -361,8 +349,7 @@ class NumWords(TransformPrimitive):
     name = 'num_words'
     input_types = [Text]
     return_type = Numeric
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def get_function(self):
         def word_counter(array):
@@ -405,7 +392,7 @@ class TimeSince(TransformPrimitive):
     input_types = [Datetime]
     return_type = Numeric
     uses_calc_time = True
-    dask_compatible = True
+    compatibility = ['dask']
 
     def __init__(self, unit="seconds"):
         self.unit = unit.lower()
@@ -428,8 +415,7 @@ class IsIn(TransformPrimitive):
     name = "isin"
     input_types = [Variable]
     return_type = Boolean
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def __init__(self, list_of_outputs=None):
         self.list_of_outputs = list_of_outputs
@@ -482,8 +468,7 @@ class Negate(TransformPrimitive):
     name = "negate"
     input_types = [Numeric]
     return_type = Numeric
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def get_function(self):
         def negate(vals):
@@ -505,8 +490,7 @@ class Not(TransformPrimitive):
     name = "not"
     input_types = [Boolean]
     return_type = Boolean
-    dask_compatible = True
-    koalas_compatible = True
+    compatibility = ['dask', 'koalas']
 
     def generate_name(self, base_feature_names):
         return u"NOT({})".format(base_feature_names[0])
@@ -674,7 +658,7 @@ class Age(TransformPrimitive):
     input_types = [DateOfBirth]
     return_type = Numeric
     uses_calc_time = True
-    dask_compatible = True
+    compatibility = ['dask']
 
     def get_function(self):
         def age(x, time=None):

--- a/featuretools/primitives/standard/transform_primitive.py
+++ b/featuretools/primitives/standard/transform_primitive.py
@@ -7,7 +7,7 @@ from featuretools.primitives.base.transform_primitive_base import (
 )
 from featuretools.utils import convert_time_units
 from featuretools.utils.entity_utils import replace_latlong_nan
-from featuretools.utils.gen_utils import Lib
+from featuretools.utils.gen_utils import Library
 from featuretools.variable_types import (
     Boolean,
     DateOfBirth,
@@ -32,7 +32,7 @@ class IsNull(TransformPrimitive):
     name = "is_null"
     input_types = [Variable]
     return_type = Boolean
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def isnull(array):
@@ -51,7 +51,7 @@ class Absolute(TransformPrimitive):
     name = "absolute"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def get_function(self):
         return np.absolute
@@ -109,7 +109,7 @@ class Day(TransformPrimitive):
     name = "day"
     input_types = [Datetime]
     return_type = Ordinal
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def day(vals):
@@ -132,7 +132,7 @@ class Hour(TransformPrimitive):
     name = "hour"
     input_types = [Datetime]
     return_type = Ordinal
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def hour(vals):
@@ -155,7 +155,7 @@ class Second(TransformPrimitive):
     name = "second"
     input_types = [Datetime]
     return_type = Numeric
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def second(vals):
@@ -178,7 +178,7 @@ class Minute(TransformPrimitive):
     name = "minute"
     input_types = [Datetime]
     return_type = Numeric
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def minute(vals):
@@ -206,7 +206,7 @@ class Week(TransformPrimitive):
     name = "week"
     input_types = [Datetime]
     return_type = Ordinal
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def week(vals):
@@ -234,7 +234,7 @@ class Month(TransformPrimitive):
     name = "month"
     input_types = [Datetime]
     return_type = Ordinal
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def month(vals):
@@ -257,7 +257,7 @@ class Year(TransformPrimitive):
     name = "year"
     input_types = [Datetime]
     return_type = Ordinal
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def year(vals):
@@ -280,7 +280,7 @@ class IsWeekend(TransformPrimitive):
     name = "is_weekend"
     input_types = [Datetime]
     return_type = Boolean
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def is_weekend(vals):
@@ -307,7 +307,7 @@ class Weekday(TransformPrimitive):
     name = "weekday"
     input_types = [Datetime]
     return_type = Ordinal
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def weekday(vals):
@@ -328,7 +328,7 @@ class NumCharacters(TransformPrimitive):
     name = 'num_characters'
     input_types = [Text]
     return_type = Numeric
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def character_counter(array):
@@ -350,7 +350,7 @@ class NumWords(TransformPrimitive):
     name = 'num_words'
     input_types = [Text]
     return_type = Numeric
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def word_counter(array):
@@ -393,7 +393,7 @@ class TimeSince(TransformPrimitive):
     input_types = [Datetime]
     return_type = Numeric
     uses_calc_time = True
-    compatibility = [Lib.DASK]
+    compatibility = [Library.DASK]
 
     def __init__(self, unit="seconds"):
         self.unit = unit.lower()
@@ -416,7 +416,7 @@ class IsIn(TransformPrimitive):
     name = "isin"
     input_types = [Variable]
     return_type = Boolean
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def __init__(self, list_of_outputs=None):
         self.list_of_outputs = list_of_outputs
@@ -469,7 +469,7 @@ class Negate(TransformPrimitive):
     name = "negate"
     input_types = [Numeric]
     return_type = Numeric
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def get_function(self):
         def negate(vals):
@@ -491,7 +491,7 @@ class Not(TransformPrimitive):
     name = "not"
     input_types = [Boolean]
     return_type = Boolean
-    compatibility = [Lib.DASK, Lib.KOALAS]
+    compatibility = [Library.DASK, Library.KOALAS]
 
     def generate_name(self, base_feature_names):
         return u"NOT({})".format(base_feature_names[0])
@@ -659,7 +659,7 @@ class Age(TransformPrimitive):
     input_types = [DateOfBirth]
     return_type = Numeric
     uses_calc_time = True
-    compatibility = [Lib.DASK]
+    compatibility = [Library.DASK]
 
     def get_function(self):
         def age(x, time=None):

--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -10,7 +10,7 @@ from featuretools.primitives.base import (
     PrimitiveBase,
     TransformPrimitive
 )
-from featuretools.utils.gen_utils import find_descendents
+from featuretools.utils.gen_utils import Lib, find_descendents
 
 
 def get_aggregation_primitives():
@@ -39,8 +39,8 @@ def get_transform_primitives():
 
 def list_primitives():
     trans_names, trans_primitives = _get_names_primitives(get_transform_primitives)
-    trans_dask = ['dask' in primitive.compatibility for primitive in trans_primitives]
-    trans_koalas = ['koalas' in primitive.compatibility for primitive in trans_primitives]
+    trans_dask = [Lib.DASK in primitive.compatibility for primitive in trans_primitives]
+    trans_koalas = [Lib.KOALAS in primitive.compatibility for primitive in trans_primitives]
     transform_df = pd.DataFrame({'name': trans_names,
                                  'description': _get_descriptions(trans_primitives),
                                  'dask_compatible': trans_dask,
@@ -48,8 +48,8 @@ def list_primitives():
     transform_df['type'] = 'transform'
 
     agg_names, agg_primitives = _get_names_primitives(get_aggregation_primitives)
-    agg_dask = ['dask' in primitive.compatibility for primitive in agg_primitives]
-    agg_koalas = ['koalas' in primitive.compatibility for primitive in agg_primitives]
+    agg_dask = [Lib.DASK in primitive.compatibility for primitive in agg_primitives]
+    agg_koalas = [Lib.KOALAS in primitive.compatibility for primitive in agg_primitives]
     agg_df = pd.DataFrame({'name': agg_names,
                            'description': _get_descriptions(agg_primitives),
                            'dask_compatible': agg_dask,

--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -40,19 +40,23 @@ def get_transform_primitives():
 def list_primitives():
     trans_names, trans_primitives = _get_names_primitives(get_transform_primitives)
     trans_dask = ['dask' in primitive.compatibility for primitive in trans_primitives]
+    trans_koalas = ['koalas' in primitive.compatibility for primitive in trans_primitives]
     transform_df = pd.DataFrame({'name': trans_names,
                                  'description': _get_descriptions(trans_primitives),
-                                 'dask_compatible': trans_dask})
+                                 'dask_compatible': trans_dask,
+                                 'koalas_compatible': trans_koalas})
     transform_df['type'] = 'transform'
 
     agg_names, agg_primitives = _get_names_primitives(get_aggregation_primitives)
     agg_dask = ['dask' in primitive.compatibility for primitive in agg_primitives]
+    agg_koalas = ['koalas' in primitive.compatibility for primitive in agg_primitives]
     agg_df = pd.DataFrame({'name': agg_names,
                            'description': _get_descriptions(agg_primitives),
-                           'dask_compatible': agg_dask})
+                           'dask_compatible': agg_dask,
+                           'koalas_compatible': agg_koalas})
     agg_df['type'] = 'aggregation'
 
-    return pd.concat([agg_df, transform_df], ignore_index=True)[['name', 'type', 'dask_compatible', 'description']]
+    return pd.concat([agg_df, transform_df], ignore_index=True)[['name', 'type', 'dask_compatible', 'koalas_compatible', 'description']]
 
 
 def get_default_aggregation_primitives():

--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -13,6 +13,7 @@ from featuretools.primitives.base import (
 from featuretools.utils.gen_utils import Library, find_descendents
 
 
+# returns all aggregation primitives, regardless of compatibility
 def get_aggregation_primitives():
     aggregation_primitives = set([])
     for attribute_string in dir(featuretools.primitives):
@@ -25,6 +26,7 @@ def get_aggregation_primitives():
     return {prim.name.lower(): prim for prim in aggregation_primitives}
 
 
+# returns all transform primitives, regardless of compatibility
 def get_transform_primitives():
     transform_primitives = set([])
     for attribute_string in dir(featuretools.primitives):

--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -10,7 +10,7 @@ from featuretools.primitives.base import (
     PrimitiveBase,
     TransformPrimitive
 )
-from featuretools.utils.gen_utils import Lib, find_descendents
+from featuretools.utils.gen_utils import Library, find_descendents
 
 
 def get_aggregation_primitives():
@@ -39,8 +39,8 @@ def get_transform_primitives():
 
 def list_primitives():
     trans_names, trans_primitives = _get_names_primitives(get_transform_primitives)
-    trans_dask = [Lib.DASK in primitive.compatibility for primitive in trans_primitives]
-    trans_koalas = [Lib.KOALAS in primitive.compatibility for primitive in trans_primitives]
+    trans_dask = [Library.DASK in primitive.compatibility for primitive in trans_primitives]
+    trans_koalas = [Library.KOALAS in primitive.compatibility for primitive in trans_primitives]
     transform_df = pd.DataFrame({'name': trans_names,
                                  'description': _get_descriptions(trans_primitives),
                                  'dask_compatible': trans_dask,
@@ -48,8 +48,8 @@ def list_primitives():
     transform_df['type'] = 'transform'
 
     agg_names, agg_primitives = _get_names_primitives(get_aggregation_primitives)
-    agg_dask = [Lib.DASK in primitive.compatibility for primitive in agg_primitives]
-    agg_koalas = [Lib.KOALAS in primitive.compatibility for primitive in agg_primitives]
+    agg_dask = [Library.DASK in primitive.compatibility for primitive in agg_primitives]
+    agg_koalas = [Library.KOALAS in primitive.compatibility for primitive in agg_primitives]
     agg_df = pd.DataFrame({'name': agg_names,
                            'description': _get_descriptions(agg_primitives),
                            'dask_compatible': agg_dask,

--- a/featuretools/primitives/utils.py
+++ b/featuretools/primitives/utils.py
@@ -39,14 +39,14 @@ def get_transform_primitives():
 
 def list_primitives():
     trans_names, trans_primitives = _get_names_primitives(get_transform_primitives)
-    trans_dask = [primitive.dask_compatible for primitive in trans_primitives]
+    trans_dask = ['dask' in primitive.compatibility for primitive in trans_primitives]
     transform_df = pd.DataFrame({'name': trans_names,
                                  'description': _get_descriptions(trans_primitives),
                                  'dask_compatible': trans_dask})
     transform_df['type'] = 'transform'
 
     agg_names, agg_primitives = _get_names_primitives(get_aggregation_primitives)
-    agg_dask = [primitive.dask_compatible for primitive in agg_primitives]
+    agg_dask = ['dask' in primitive.compatibility for primitive in agg_primitives]
     agg_df = pd.DataFrame({'name': agg_names,
                            'description': _get_descriptions(agg_primitives),
                            'dask_compatible': agg_dask})

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -23,7 +23,7 @@ from featuretools.primitives.options_utils import (
     generate_all_primitive_options,
     ignore_entity_for_primitive
 )
-from featuretools.utils.gen_utils import import_or_none, is_instance
+from featuretools.utils.gen_utils import Lib, import_or_none, is_instance
 from featuretools.variable_types import Boolean, Discrete, Id, Numeric
 
 ks = import_or_none('databricks.koalas')
@@ -184,9 +184,9 @@ class DeepFeatureSynthesis(object):
         if agg_primitives is None:
             agg_primitives = primitives.get_default_aggregation_primitives()
             if any(isinstance(e.df, dd.DataFrame) for e in self.es.entities):
-                agg_primitives = [p for p in agg_primitives if 'dask' in p.compatibility]
+                agg_primitives = [p for p in agg_primitives if Lib.DASK in p.compatibility]
             if any(is_instance(e.df, ks, 'DataFrame') for e in self.es.entities):
-                agg_primitives = [p for p in agg_primitives if 'koalas' in p.compatibility]
+                agg_primitives = [p for p in agg_primitives if Lib.KOALAS in p.compatibility]
         self.agg_primitives = []
         agg_prim_dict = primitives.get_aggregation_primitives()
         for a in agg_primitives:
@@ -205,9 +205,9 @@ class DeepFeatureSynthesis(object):
         if trans_primitives is None:
             trans_primitives = primitives.get_default_transform_primitives()
             if any(isinstance(e.df, dd.DataFrame) for e in self.es.entities):
-                trans_primitives = [p for p in trans_primitives if 'dask' in p.compatibility]
+                trans_primitives = [p for p in trans_primitives if Lib.DASK in p.compatibility]
             if any(is_instance(e.df, ks, 'DataFrame') for e in self.es.entities):
-                trans_primitives = [p for p in trans_primitives if 'koalas' in p.compatibility]
+                trans_primitives = [p for p in trans_primitives if Lib.KOALAS in p.compatibility]
         self.trans_primitives = []
         for t in trans_primitives:
             t = check_trans_primitive(t)
@@ -239,12 +239,12 @@ class DeepFeatureSynthesis(object):
         all_primitives = self.trans_primitives + self.agg_primitives + \
             self.where_primitives + self.groupby_trans_primitives
         if any(isinstance(entity.df, dd.DataFrame) for entity in self.es.entities):
-            if not all(['dask' in primitive.compatibility for primitive in all_primitives]):
-                bad_primitives = ", ".join([prim.name for prim in all_primitives if 'dask' not in prim.compatibility])
+            if not all([Lib.DASK in primitive.compatibility for primitive in all_primitives]):
+                bad_primitives = ", ".join([prim.name for prim in all_primitives if Lib.DASK not in prim.compatibility])
                 raise ValueError('Selected primitives are incompatible with Dask EntitySets: {}'.format(bad_primitives))
         if any(is_instance(entity.df, ks, 'DataFrame') for entity in self.es.entities):
-            if not all(['koalas' in primitive.compatibility for primitive in all_primitives]):
-                bad_primitives = ", ".join([prim.name for prim in all_primitives if 'koalas' not in prim.compatibility])
+            if not all([Lib.KOALAS in primitive.compatibility for primitive in all_primitives]):
+                bad_primitives = ", ".join([prim.name for prim in all_primitives if Lib.KOALAS not in prim.compatibility])
                 raise ValueError('Selected primitives are incompatible with Koalas EntitySets: {}'.format(bad_primitives))
 
         self.primitive_options, self.ignore_entities, self.ignore_variables =\

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -23,7 +23,7 @@ from featuretools.primitives.options_utils import (
     generate_all_primitive_options,
     ignore_entity_for_primitive
 )
-from featuretools.utils.gen_utils import Lib, import_or_none, is_instance
+from featuretools.utils.gen_utils import Library, import_or_none, is_instance
 from featuretools.variable_types import Boolean, Discrete, Id, Numeric
 
 ks = import_or_none('databricks.koalas')
@@ -184,9 +184,9 @@ class DeepFeatureSynthesis(object):
         if agg_primitives is None:
             agg_primitives = primitives.get_default_aggregation_primitives()
             if any(isinstance(e.df, dd.DataFrame) for e in self.es.entities):
-                agg_primitives = [p for p in agg_primitives if Lib.DASK in p.compatibility]
+                agg_primitives = [p for p in agg_primitives if Library.DASK in p.compatibility]
             if any(is_instance(e.df, ks, 'DataFrame') for e in self.es.entities):
-                agg_primitives = [p for p in agg_primitives if Lib.KOALAS in p.compatibility]
+                agg_primitives = [p for p in agg_primitives if Library.KOALAS in p.compatibility]
         self.agg_primitives = []
         agg_prim_dict = primitives.get_aggregation_primitives()
         for a in agg_primitives:
@@ -205,9 +205,9 @@ class DeepFeatureSynthesis(object):
         if trans_primitives is None:
             trans_primitives = primitives.get_default_transform_primitives()
             if any(isinstance(e.df, dd.DataFrame) for e in self.es.entities):
-                trans_primitives = [p for p in trans_primitives if Lib.DASK in p.compatibility]
+                trans_primitives = [p for p in trans_primitives if Library.DASK in p.compatibility]
             if any(is_instance(e.df, ks, 'DataFrame') for e in self.es.entities):
-                trans_primitives = [p for p in trans_primitives if Lib.KOALAS in p.compatibility]
+                trans_primitives = [p for p in trans_primitives if Library.KOALAS in p.compatibility]
         self.trans_primitives = []
         for t in trans_primitives:
             t = check_trans_primitive(t)
@@ -239,12 +239,12 @@ class DeepFeatureSynthesis(object):
         all_primitives = self.trans_primitives + self.agg_primitives + \
             self.where_primitives + self.groupby_trans_primitives
         if any(isinstance(entity.df, dd.DataFrame) for entity in self.es.entities):
-            if not all([Lib.DASK in primitive.compatibility for primitive in all_primitives]):
-                bad_primitives = ", ".join([prim.name for prim in all_primitives if Lib.DASK not in prim.compatibility])
+            if not all([Library.DASK in primitive.compatibility for primitive in all_primitives]):
+                bad_primitives = ", ".join([prim.name for prim in all_primitives if Library.DASK not in prim.compatibility])
                 raise ValueError('Selected primitives are incompatible with Dask EntitySets: {}'.format(bad_primitives))
         if any(is_instance(entity.df, ks, 'DataFrame') for entity in self.es.entities):
-            if not all([Lib.KOALAS in primitive.compatibility for primitive in all_primitives]):
-                bad_primitives = ", ".join([prim.name for prim in all_primitives if Lib.KOALAS not in prim.compatibility])
+            if not all([Library.KOALAS in primitive.compatibility for primitive in all_primitives]):
+                bad_primitives = ", ".join([prim.name for prim in all_primitives if Library.KOALAS not in prim.compatibility])
                 raise ValueError('Selected primitives are incompatible with Koalas EntitySets: {}'.format(bad_primitives))
 
         self.primitive_options, self.ignore_entities, self.ignore_variables =\

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -184,9 +184,9 @@ class DeepFeatureSynthesis(object):
         if agg_primitives is None:
             agg_primitives = primitives.get_default_aggregation_primitives()
             if any(isinstance(e.df, dd.DataFrame) for e in self.es.entities):
-                agg_primitives = [p for p in agg_primitives if p.dask_compatible]
+                agg_primitives = [p for p in agg_primitives if 'dask' in p.compatibility]
             if any(is_instance(e.df, ks, 'DataFrame') for e in self.es.entities):
-                agg_primitives = [p for p in agg_primitives if p.koalas_compatible]
+                agg_primitives = [p for p in agg_primitives if 'koalas' in p.compatibility]
         self.agg_primitives = []
         agg_prim_dict = primitives.get_aggregation_primitives()
         for a in agg_primitives:
@@ -205,9 +205,9 @@ class DeepFeatureSynthesis(object):
         if trans_primitives is None:
             trans_primitives = primitives.get_default_transform_primitives()
             if any(isinstance(e.df, dd.DataFrame) for e in self.es.entities):
-                trans_primitives = [p for p in trans_primitives if p.dask_compatible]
+                trans_primitives = [p for p in trans_primitives if 'dask' in p.compatibility]
             if any(is_instance(e.df, ks, 'DataFrame') for e in self.es.entities):
-                trans_primitives = [p for p in trans_primitives if p.koalas_compatible]
+                trans_primitives = [p for p in trans_primitives if 'koalas' in p.compatibility]
         self.trans_primitives = []
         for t in trans_primitives:
             t = check_trans_primitive(t)
@@ -239,12 +239,12 @@ class DeepFeatureSynthesis(object):
         all_primitives = self.trans_primitives + self.agg_primitives + \
             self.where_primitives + self.groupby_trans_primitives
         if any(isinstance(entity.df, dd.DataFrame) for entity in self.es.entities):
-            if not all([primitive.dask_compatible for primitive in all_primitives]):
-                bad_primitives = ", ".join([prim.name for prim in all_primitives if not prim.dask_compatible])
+            if not all(['dask' in primitive.compatibility for primitive in all_primitives]):
+                bad_primitives = ", ".join([prim.name for prim in all_primitives if 'dask' not in prim.compatibility])
                 raise ValueError('Selected primitives are incompatible with Dask EntitySets: {}'.format(bad_primitives))
         if any(is_instance(entity.df, ks, 'DataFrame') for entity in self.es.entities):
-            if not all([primitive.koalas_compatible for primitive in all_primitives]):
-                bad_primitives = ", ".join([prim.name for prim in all_primitives if not prim.dask_compatible])
+            if not all(['koalas' in primitive.compatibility for primitive in all_primitives]):
+                bad_primitives = ", ".join([prim.name for prim in all_primitives if 'koalas' not in prim.compatibility])
                 raise ValueError('Selected primitives are incompatible with Koalas EntitySets: {}'.format(bad_primitives))
 
         self.primitive_options, self.ignore_entities, self.ignore_variables =\

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -239,7 +239,8 @@ class DeepFeatureSynthesis(object):
             self.where_primitives + self.groupby_trans_primitives
         bad_primitives = [prim.name for prim in all_primitives if entityset_type not in prim.compatibility]
         if bad_primitives:
-            raise ValueError('Selected primitives are incompatible with {} EntitySets: {}'.format(entityset_type.value, ', '.join(bad_primitives)))
+            msg = 'Selected primitives are incompatible with {} EntitySets: {}'
+            raise ValueError(msg.format(entityset_type.value, ', '.join(bad_primitives)))
 
         self.primitive_options, self.ignore_entities, self.ignore_variables =\
             generate_all_primitive_options(all_primitives,

--- a/featuretools/synthesis/deep_feature_synthesis.py
+++ b/featuretools/synthesis/deep_feature_synthesis.py
@@ -1,6 +1,7 @@
 import logging
 from collections import defaultdict
 
+import pandas as pd
 from dask import dataframe as dd
 
 from featuretools import primitives, variable_types
@@ -238,6 +239,10 @@ class DeepFeatureSynthesis(object):
             primitive_options = {}
         all_primitives = self.trans_primitives + self.agg_primitives + \
             self.where_primitives + self.groupby_trans_primitives
+        if any(isinstance(entity.df, pd.DataFrame) for entity in self.es.entities):
+            if not all([Library.PANDAS in primitive.compatibility for primitive in all_primitives]):
+                bad_primitives = ", ".join([prim.name for prim in all_primitives if Library.PANDAS not in prim.compatibility])
+                raise ValueError('Selected primitives are incompatible with pandas EntitySets: {}'.format(bad_primitives))
         if any(isinstance(entity.df, dd.DataFrame) for entity in self.es.entities):
             if not all([Library.DASK in primitive.compatibility for primitive in all_primitives]):
                 bad_primitives = ", ".join([prim.name for prim in all_primitives if Library.DASK not in prim.compatibility])

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -1738,7 +1738,7 @@ def test_closes_tqdm(es):
         name = "error_prim"
         input_types = [ft.variable_types.Numeric]
         return_type = "Numeric"
-        dask_compatible = True
+        compatibility = ['dask', 'koalas']
 
         def get_function(self):
             def error(s):

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -47,7 +47,7 @@ from featuretools.tests.testing_utils import (
     get_mock_client_cluster,
     to_pandas
 )
-from featuretools.utils.gen_utils import import_or_none
+from featuretools.utils.gen_utils import Lib, import_or_none
 
 ks = import_or_none('databricks.koalas')
 
@@ -1738,7 +1738,7 @@ def test_closes_tqdm(es):
         name = "error_prim"
         input_types = [ft.variable_types.Numeric]
         return_type = "Numeric"
-        compatibility = ['dask', 'koalas']
+        compatibility = [Lib.DASK, Lib.KOALAS]
 
         def get_function(self):
             def error(s):

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -1728,7 +1728,7 @@ def test_closes_tqdm(es):
         name = "error_prim"
         input_types = [ft.variable_types.Numeric]
         return_type = "Numeric"
-        compatibility = [Library.DASK, Library.KOALAS]
+        compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
         def get_function(self):
             def error(s):

--- a/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
+++ b/featuretools/tests/computational_backend/test_calculate_feature_matrix.py
@@ -47,7 +47,7 @@ from featuretools.tests.testing_utils import (
     get_mock_client_cluster,
     to_pandas
 )
-from featuretools.utils.gen_utils import Lib, import_or_none
+from featuretools.utils.gen_utils import Library, import_or_none
 
 ks = import_or_none('databricks.koalas')
 
@@ -1728,7 +1728,7 @@ def test_closes_tqdm(es):
         name = "error_prim"
         input_types = [ft.variable_types.Numeric]
         return_type = "Numeric"
-        compatibility = [Lib.DASK, Lib.KOALAS]
+        compatibility = [Library.DASK, Library.KOALAS]
 
         def get_function(self):
             def error(s):

--- a/featuretools/tests/computational_backend/test_feature_set_calculator.py
+++ b/featuretools/tests/computational_backend/test_feature_set_calculator.py
@@ -871,23 +871,11 @@ def test_handles_primitive_function_name_uniqueness(es):
         def __init__(self, n):
             self.n = n
 
-        def get_function(self):
+        def get_function(self, agg_type='pandas'):
             def my_function(values):
                 return values.sum() * self.n
 
             return my_function
-
-        def get_dask_aggregation(self):
-            def chunk(s):
-                return s.sum()
-
-            def agg(s):
-                return s.sum()
-
-            def finalize(s):
-                return s * self.n
-
-            return dd.Aggregation(self.name, chunk=chunk, agg=agg, finalize=finalize)
 
     # works as expected
     f1 = ft.Feature(es["log"]["value"],
@@ -943,7 +931,7 @@ def test_handles_primitive_function_name_uniqueness(es):
         stack_on_exclude = [Count]
         default_value = 0
 
-        def get_function(self):
+        def get_function(self, agg_type='pandas'):
             return np.sum
 
     class Sum2(AggregationPrimitive):
@@ -955,7 +943,7 @@ def test_handles_primitive_function_name_uniqueness(es):
         stack_on_exclude = [Count]
         default_value = 0
 
-        def get_function(self):
+        def get_function(self, agg_type='pandas'):
             return np.sum
 
     class Sum3(AggregationPrimitive):
@@ -967,7 +955,7 @@ def test_handles_primitive_function_name_uniqueness(es):
         stack_on_exclude = [Count]
         default_value = 0
 
-        def get_function(self):
+        def get_function(self, agg_type='pandas'):
             return np.sum
 
     f5 = ft.Feature(es["log"]["value"],
@@ -1056,7 +1044,7 @@ def test_precalculated_features(pd_es):
         input_types = [Numeric]
         return_type = Numeric
 
-        def get_function(self):
+        def get_function(self, agg_type='pandas'):
             def error(s):
                 raise RuntimeError(error_msg)
             return error

--- a/featuretools/tests/primitive_tests/test_agg_feats.py
+++ b/featuretools/tests/primitive_tests/test_agg_feats.py
@@ -38,7 +38,7 @@ from featuretools.tests.testing_utils import (
     feature_with_name,
     to_pandas
 )
-from featuretools.utils.gen_utils import Lib, import_or_none
+from featuretools.utils.gen_utils import Library, import_or_none
 from featuretools.variable_types import (
     Datetime,
     DatetimeTimeIndex,
@@ -229,9 +229,9 @@ def test_init_and_name(es):
     agg_primitives = get_aggregation_primitives().values()
     # If Dask EntitySet use only Dask compatible primitives
     if isinstance(es['sessions'].df, dd.DataFrame):
-        agg_primitives = [prim for prim in agg_primitives if Lib.DASK in prim.compatibility]
+        agg_primitives = [prim for prim in agg_primitives if Library.DASK in prim.compatibility]
     if ks and isinstance(es['sessions'].df, ks.DataFrame):
-        agg_primitives = [prim for prim in agg_primitives if Lib.KOALAS in prim.compatibility]
+        agg_primitives = [prim for prim in agg_primitives if Library.KOALAS in prim.compatibility]
 
     for agg_prim in agg_primitives:
         input_types = agg_prim.input_types

--- a/featuretools/tests/primitive_tests/test_agg_feats.py
+++ b/featuretools/tests/primitive_tests/test_agg_feats.py
@@ -38,7 +38,7 @@ from featuretools.tests.testing_utils import (
     feature_with_name,
     to_pandas
 )
-from featuretools.utils.gen_utils import import_or_none
+from featuretools.utils.gen_utils import Lib, import_or_none
 from featuretools.variable_types import (
     Datetime,
     DatetimeTimeIndex,
@@ -229,9 +229,9 @@ def test_init_and_name(es):
     agg_primitives = get_aggregation_primitives().values()
     # If Dask EntitySet use only Dask compatible primitives
     if isinstance(es['sessions'].df, dd.DataFrame):
-        agg_primitives = [prim for prim in agg_primitives if 'dask' in prim.compatibility]
+        agg_primitives = [prim for prim in agg_primitives if Lib.DASK in prim.compatibility]
     if ks and isinstance(es['sessions'].df, ks.DataFrame):
-        agg_primitives = [prim for prim in agg_primitives if 'koalas' in prim.compatibility]
+        agg_primitives = [prim for prim in agg_primitives if Lib.KOALAS in prim.compatibility]
 
     for agg_prim in agg_primitives:
         input_types = agg_prim.input_types

--- a/featuretools/tests/primitive_tests/test_agg_feats.py
+++ b/featuretools/tests/primitive_tests/test_agg_feats.py
@@ -59,7 +59,7 @@ def test_primitive():
         return_type = Numeric
         stack_on = []
 
-        def get_function(self):
+        def get_function(self, agg_type='pandas'):
             return None
 
     return TestAgg
@@ -229,9 +229,9 @@ def test_init_and_name(es):
     agg_primitives = get_aggregation_primitives().values()
     # If Dask EntitySet use only Dask compatible primitives
     if isinstance(es['sessions'].df, dd.DataFrame):
-        agg_primitives = [prim for prim in agg_primitives if prim.dask_compatible]
+        agg_primitives = [prim for prim in agg_primitives if 'dask' in prim.compatibility]
     if ks and isinstance(es['sessions'].df, ks.DataFrame):
-        agg_primitives = [prim for prim in agg_primitives if prim.koalas_compatible]
+        agg_primitives = [prim for prim in agg_primitives if 'koalas' in prim.compatibility]
 
     for agg_prim in agg_primitives:
         input_types = agg_prim.input_types

--- a/featuretools/tests/primitive_tests/test_dask_primitives.py
+++ b/featuretools/tests/primitive_tests/test_dask_primitives.py
@@ -5,9 +5,10 @@ from featuretools.primitives import (
     get_aggregation_primitives,
     get_transform_primitives
 )
+from featuretools.utils.gen_utils import Lib
 
-UNSUPPORTED = [p.name for p in get_transform_primitives().values() if 'dask' not in p.compatibility]
-UNSUPPORTED += [p.name for p in get_aggregation_primitives().values() if 'dask' not in p.compatibility]
+UNSUPPORTED = [p.name for p in get_transform_primitives().values() if Lib.DASK not in p.compatibility]
+UNSUPPORTED += [p.name for p in get_aggregation_primitives().values() if Lib.DASK not in p.compatibility]
 
 
 def test_transform(pd_es, dask_es):

--- a/featuretools/tests/primitive_tests/test_dask_primitives.py
+++ b/featuretools/tests/primitive_tests/test_dask_primitives.py
@@ -6,8 +6,8 @@ from featuretools.primitives import (
     get_transform_primitives
 )
 
-UNSUPPORTED = [p.name for p in get_transform_primitives().values() if not p.dask_compatible]
-UNSUPPORTED += [p.name for p in get_aggregation_primitives().values() if not p.dask_compatible]
+UNSUPPORTED = [p.name for p in get_transform_primitives().values() if 'dask' not in p.compatibility]
+UNSUPPORTED += [p.name for p in get_aggregation_primitives().values() if 'dask' not in p.compatibility]
 
 
 def test_transform(pd_es, dask_es):

--- a/featuretools/tests/primitive_tests/test_dask_primitives.py
+++ b/featuretools/tests/primitive_tests/test_dask_primitives.py
@@ -5,10 +5,10 @@ from featuretools.primitives import (
     get_aggregation_primitives,
     get_transform_primitives
 )
-from featuretools.utils.gen_utils import Lib
+from featuretools.utils.gen_utils import Library
 
-UNSUPPORTED = [p.name for p in get_transform_primitives().values() if Lib.DASK not in p.compatibility]
-UNSUPPORTED += [p.name for p in get_aggregation_primitives().values() if Lib.DASK not in p.compatibility]
+UNSUPPORTED = [p.name for p in get_transform_primitives().values() if Library.DASK not in p.compatibility]
+UNSUPPORTED += [p.name for p in get_aggregation_primitives().values() if Library.DASK not in p.compatibility]
 
 
 def test_transform(pd_es, dask_es):

--- a/featuretools/tests/primitive_tests/test_direct_features.py
+++ b/featuretools/tests/primitive_tests/test_direct_features.py
@@ -132,7 +132,7 @@ def test_direct_features_of_multi_output_agg_primitives(pd_es):
         return_type = Categorical
         number_output_features = 3
 
-        def get_function(self):
+        def get_function(self, agg_type='pandas'):
             def pd_top3(x):
                 array = np.array(x.value_counts()[:3].index)
                 if len(array) < 3:

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -59,7 +59,7 @@ from featuretools.primitives.utils import (
 )
 from featuretools.synthesis.deep_feature_synthesis import match
 from featuretools.tests.testing_utils import feature_with_name, to_pandas
-from featuretools.utils.gen_utils import Lib, import_or_none
+from featuretools.utils.gen_utils import Library, import_or_none
 from featuretools.variable_types import Boolean, Datetime, Numeric, Variable
 
 ks = import_or_none('databricks.koalas')
@@ -76,9 +76,9 @@ def test_init_and_name(es):
     trans_primitives = get_transform_primitives().values()
     # If Dask EntitySet use only Dask compatible primitives
     if isinstance(es['log'].df, dd.DataFrame):
-        trans_primitives = [prim for prim in trans_primitives if Lib.DASK in prim.compatibility]
+        trans_primitives = [prim for prim in trans_primitives if Library.DASK in prim.compatibility]
     if ks and isinstance(es['log'].df, ks.DataFrame):
-        trans_primitives = [prim for prim in trans_primitives if Lib.KOALAS in prim.compatibility]
+        trans_primitives = [prim for prim in trans_primitives if Library.KOALAS in prim.compatibility]
     for transform_prim in trans_primitives:
         # skip automated testing if a few special cases
         features_to_use = log_features
@@ -1053,7 +1053,7 @@ def test_get_filepath(es):
         name = "mod4"
         input_types = [Numeric]
         return_type = Numeric
-        compatibility = [Lib.DASK, Lib.KOALAS]
+        compatibility = [Library.DASK, Library.KOALAS]
 
         def get_function(self):
             filepath = self.get_filepath("featuretools_unit_test_example.csv")

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -59,7 +59,7 @@ from featuretools.primitives.utils import (
 )
 from featuretools.synthesis.deep_feature_synthesis import match
 from featuretools.tests.testing_utils import feature_with_name, to_pandas
-from featuretools.utils.gen_utils import import_or_none
+from featuretools.utils.gen_utils import Lib, import_or_none
 from featuretools.variable_types import Boolean, Datetime, Numeric, Variable
 
 ks = import_or_none('databricks.koalas')
@@ -76,9 +76,9 @@ def test_init_and_name(es):
     trans_primitives = get_transform_primitives().values()
     # If Dask EntitySet use only Dask compatible primitives
     if isinstance(es['log'].df, dd.DataFrame):
-        trans_primitives = [prim for prim in trans_primitives if 'dask' in prim.compatibility]
+        trans_primitives = [prim for prim in trans_primitives if Lib.DASK in prim.compatibility]
     if ks and isinstance(es['log'].df, ks.DataFrame):
-        trans_primitives = [prim for prim in trans_primitives if 'koalas' in prim.compatibility]
+        trans_primitives = [prim for prim in trans_primitives if Lib.KOALAS in prim.compatibility]
     for transform_prim in trans_primitives:
         # skip automated testing if a few special cases
         features_to_use = log_features
@@ -1053,7 +1053,7 @@ def test_get_filepath(es):
         name = "mod4"
         input_types = [Numeric]
         return_type = Numeric
-        compatibility = ['dask', 'koalas']
+        compatibility = [Lib.DASK, Lib.KOALAS]
 
         def get_function(self):
             filepath = self.get_filepath("featuretools_unit_test_example.csv")

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -1053,7 +1053,7 @@ def test_get_filepath(es):
         name = "mod4"
         input_types = [Numeric]
         return_type = Numeric
-        compatibility = [Library.DASK, Library.KOALAS]
+        compatibility = [Library.PANDAS, Library.DASK, Library.KOALAS]
 
         def get_function(self):
             filepath = self.get_filepath("featuretools_unit_test_example.csv")

--- a/featuretools/tests/primitive_tests/test_transform_features.py
+++ b/featuretools/tests/primitive_tests/test_transform_features.py
@@ -76,9 +76,9 @@ def test_init_and_name(es):
     trans_primitives = get_transform_primitives().values()
     # If Dask EntitySet use only Dask compatible primitives
     if isinstance(es['log'].df, dd.DataFrame):
-        trans_primitives = [prim for prim in trans_primitives if prim.dask_compatible]
+        trans_primitives = [prim for prim in trans_primitives if 'dask' in prim.compatibility]
     if ks and isinstance(es['log'].df, ks.DataFrame):
-        trans_primitives = [prim for prim in trans_primitives if prim.koalas_compatible]
+        trans_primitives = [prim for prim in trans_primitives if 'koalas' in prim.compatibility]
     for transform_prim in trans_primitives:
         # skip automated testing if a few special cases
         features_to_use = log_features
@@ -1053,8 +1053,7 @@ def test_get_filepath(es):
         name = "mod4"
         input_types = [Numeric]
         return_type = Numeric
-        dask_compatible = True
-        koalas_compatible = True
+        compatibility = ['dask', 'koalas']
 
         def get_function(self):
             filepath = self.get_filepath("featuretools_unit_test_example.csv")

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -41,7 +41,7 @@ from featuretools.primitives import (
 )
 from featuretools.synthesis import DeepFeatureSynthesis
 from featuretools.tests.testing_utils import feature_with_name
-from featuretools.utils.gen_utils import Lib
+from featuretools.utils.gen_utils import Library
 from featuretools.variable_types import Datetime, Numeric
 
 
@@ -1398,7 +1398,7 @@ def test_primitive_options_commutative(es):
         input_types = [Numeric, Numeric, Numeric]
         return_type = Numeric
         commutative = True
-        compatibility = [Lib.DASK, Lib.KOALAS]
+        compatibility = [Library.DASK, Library.KOALAS]
 
         def generate_name(self, base_feature_names):
             return "%s + %s + %s" % (base_feature_names[0], base_feature_names[1], base_feature_names[2])

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -41,6 +41,7 @@ from featuretools.primitives import (
 )
 from featuretools.synthesis import DeepFeatureSynthesis
 from featuretools.tests.testing_utils import feature_with_name
+from featuretools.utils.gen_utils import Lib
 from featuretools.variable_types import Datetime, Numeric
 
 
@@ -1385,7 +1386,7 @@ def test_primitive_options_commutative(es):
         input_types = [Numeric, Numeric, Numeric]
         return_type = Numeric
         commutative = True
-        compatibility = ['dask', 'koalas']
+        compatibility = [Lib.DASK, Lib.KOALAS]
 
         def generate_name(self, base_feature_names):
             return "%s + %s + %s" % (base_feature_names[0], base_feature_names[1], base_feature_names[2])

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -170,7 +170,7 @@ def test_errors_unsupported_primitives_koalas(ks_es):
     bad_trans_prim = CumSum()
     bad_agg_prim = NumUnique()
     bad_trans_prim.koalas_compatible, bad_agg_prim.koalas_compatible = False, False
-    error_text = "Selected primitives are incompatible with Koalas EntitySets: cum_sum, num_unique"
+    error_text = "Selected primitives are incompatible with Koalas EntitySets: cum_sum"
     with pytest.raises(ValueError, match=error_text):
         DeepFeatureSynthesis(target_entity_id='sessions',
                              entityset=ks_es,

--- a/featuretools/tests/synthesis/test_deep_feature_synthesis.py
+++ b/featuretools/tests/synthesis/test_deep_feature_synthesis.py
@@ -156,7 +156,7 @@ def test_only_makes_supplied_agg_feat(es):
 def test_errors_unsupported_primitives_dask(dask_es):
     bad_trans_prim = CumSum()
     bad_agg_prim = NumUnique()
-    bad_trans_prim.dask_compatible, bad_agg_prim.dask_compatible = False, False
+    bad_trans_prim.compatibility, bad_agg_prim.compatibility = [], []
     error_text = "Selected primitives are incompatible with Dask EntitySets: cum_sum, num_unique"
     with pytest.raises(ValueError, match=error_text):
         DeepFeatureSynthesis(target_entity_id='sessions',
@@ -1384,9 +1384,8 @@ def test_primitive_options_commutative(es):
         name = 'add_three'
         input_types = [Numeric, Numeric, Numeric]
         return_type = Numeric
-        dask_compatible = True
-        koalas_compatible = True
         commutative = True
+        compatibility = ['dask', 'koalas']
 
         def generate_name(self, base_feature_names):
             return "%s + %s + %s" % (base_feature_names[0], base_feature_names[1], base_feature_names[2])

--- a/featuretools/tests/utils_tests/test_primitives_utils.py
+++ b/featuretools/tests/utils_tests/test_primitives_utils.py
@@ -26,7 +26,7 @@ from featuretools.primitives import (
     get_transform_primitives
 )
 from featuretools.primitives.utils import _get_descriptions
-from featuretools.utils.gen_utils import Lib
+from featuretools.utils.gen_utils import Library
 
 
 def test_list_primitives_order():
@@ -40,7 +40,7 @@ def test_list_primitives_order():
         actual_desc = _get_descriptions([primitive])[0]
         if actual_desc:
             assert actual_desc == row['description']
-        assert row['dask_compatible'] == (Lib.DASK in primitive.compatibility)
+        assert row['dask_compatible'] == (Library.DASK in primitive.compatibility)
 
     types = df['type'].values
     assert 'aggregation' in types

--- a/featuretools/tests/utils_tests/test_primitives_utils.py
+++ b/featuretools/tests/utils_tests/test_primitives_utils.py
@@ -39,7 +39,7 @@ def test_list_primitives_order():
         actual_desc = _get_descriptions([primitive])[0]
         if actual_desc:
             assert actual_desc == row['description']
-        assert row['dask_compatible'] == primitive.dask_compatible
+        assert row['dask_compatible'] == ('dask' in primitive.compatibility)
 
     types = df['type'].values
     assert 'aggregation' in types

--- a/featuretools/tests/utils_tests/test_primitives_utils.py
+++ b/featuretools/tests/utils_tests/test_primitives_utils.py
@@ -26,6 +26,7 @@ from featuretools.primitives import (
     get_transform_primitives
 )
 from featuretools.primitives.utils import _get_descriptions
+from featuretools.utils.gen_utils import Lib
 
 
 def test_list_primitives_order():
@@ -39,7 +40,7 @@ def test_list_primitives_order():
         actual_desc = _get_descriptions([primitive])[0]
         if actual_desc:
             assert actual_desc == row['description']
-        assert row['dask_compatible'] == ('dask' in primitive.compatibility)
+        assert row['dask_compatible'] == (Lib.DASK in primitive.compatibility)
 
     types = df['type'].values
     assert 'aggregation' in types

--- a/featuretools/utils/gen_utils.py
+++ b/featuretools/utils/gen_utils.py
@@ -3,6 +3,7 @@ import logging
 import re
 import sys
 import warnings
+from enum import Enum
 from itertools import zip_longest
 
 from tqdm import tqdm
@@ -133,3 +134,9 @@ def is_instance(obj, modules, classnames):
         raise ValueError('Number of modules does not match number of classnames')
     to_check = tuple(getattr(mod, classname, mod) for mod, classname in zip(modules, classnames) if mod)
     return isinstance(obj, to_check)
+
+
+class Lib(Enum):
+    PANDAS = 'pandas'
+    DASK = 'Dask'
+    KOALAS = 'Koalas'

--- a/featuretools/utils/gen_utils.py
+++ b/featuretools/utils/gen_utils.py
@@ -136,7 +136,7 @@ def is_instance(obj, modules, classnames):
     return isinstance(obj, to_check)
 
 
-class Lib(Enum):
+class Library(Enum):
     PANDAS = 'pandas'
     DASK = 'Dask'
     KOALAS = 'Koalas'


### PR DESCRIPTION
Fixes #1128 and #1132
- Update primitive compatibility from separate flags to a list of additional compatible libraries
- Add argument to `get_function` for aggregation primitives to return the correct aggregation for the given library
- Remove `get_dask_aggregation` from aggregation primitives