### PR TITLE
Optimize Unused Primitive Check

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 **Future Release**
     * Enhancements
     * Fixes
+        * Improve performance of unused primitive check in dfs (:pr:`1140`)
     * Changes
         * Remove the ability to stack transform primitives (:pr:`1119`)
         * Sort primitives passed to ``dfs`` to get consistent ordering of features\* (:pr:`1119`)

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -257,8 +257,10 @@ def dfs(entities=None,
                                       primitive_options=primitive_options,
                                       max_features=max_features,
                                       seed_features=seed_features)
+
     features = dfs_object.build_features(
         verbose=verbose, return_variable_types=return_variable_types)
+
     trans, agg, groupby, where = _categorize_features(features)
 
     trans_unused = get_unused_primitives(trans_primitives, trans)

--- a/featuretools/synthesis/dfs.py
+++ b/featuretools/synthesis/dfs.py
@@ -316,7 +316,7 @@ def warn_unused_primitives(unused_primitives):
 
 
 def _categorize_features(features):
-    """Categorize each feature in a list of features along with any dependencies"""
+    """Categorize each feature by its primitive type in a set of primitives along with any dependencies"""
     transform = set()
     agg = set()
     groupby = set()


### PR DESCRIPTION
The check in `dfs` for unused primitives has been blowing up at the check for unused primitives when dfs produces many features. This PR makes two changes to help slow that down:

- Instead of returning all of the features split into their primitive-type categorizations, `_categorize_features` now returns just the primitives used categorized into primitive types, meaning that if `sum` was used 4000 times, it only needs one entry in the categorization. This makes the check for unused primitives dependent on the number of possible primitives and not the number of possible features.
- `explored` in `_categorize_features` is changed to be a set so that when we check `explored` to avoid repeating features, it's a constant time check

Note: This PR will go along with a change to the performance tests [FeatureLabs/EntitySets#115](https://github.com/FeatureLabs/EntitySets/pull/115) to include a test that produces more than 50K features so that we can see the impacts of this PR and future changes that might impact `dfs` at larger numbers of features

