### PR TITLE
Update sklearn transformer requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 -r test-requirements.txt
-featuretools-sklearn-transformer >= 0.1.0
+featuretools-sklearn-transformer >= 0.1.1
 codecov==2.1.0
 flake8==3.7.8
 autopep8==1.4.4

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -10,7 +10,7 @@ Changelog
         * Fix ``encode_features`` converting excluded feature columns to a numeric dtype (:pr:`1123`)
         * Improve performance of unused primitive check in dfs (:pr:`1140`)
     * Changes
-        * Remove the ability to stack transform primitives (:pr:`1119`)
+        * Remove the ability to stack transform primitives (:pr:`1119`, :pr:`1145`)
         * Sort primitives passed to ``dfs`` to get consistent ordering of features\* (:pr:`1119`)
     * Documentation Changes
         * Added return values to dfs and calculate_feature_matrix (:pr:`1125`)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,7 +5,7 @@ pytest-xdist==1.26.1
 pytest-cov==2.6.1
 fastparquet>=0.1.6
 graphviz>=0.8.4
-moto[all]>=1.3.13
+moto[all]>=1.3.15
 smart-open>=1.8.4
 boto3>=1.10.45
 composeml>=0.2.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,7 +5,7 @@ pytest-xdist==1.26.1
 pytest-cov==2.6.1
 fastparquet>=0.1.6
 graphviz>=0.8.4
-moto>=1.3.13
+moto[all]>=1.3.13
 smart-open>=1.8.4
 boto3>=1.10.45
 composeml>=0.2.0


### PR DESCRIPTION
Update to 0.1.1 to go with the remove transform stacking PR changes.
