### PR TITLE
Serialize multi output features

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 **Future Release**
     * Enhancements
     * Fixes
+        * Allow FeatureOutputSlice features to be serialized (:pr:`1150`)
     * Changes
     * Documentation Changes
         * Update release doc for clarity and to add Future Release template (:pr:`1151`)

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -804,7 +804,7 @@ class FeatureOutputSlice(FeatureBase):
     def get_arguments(self):
         return {
             'name': self._name,
-            'base_feature': self.base_feature,
+            'base_feature': self.base_feature.unique_name(),
             'n': self.n
         }
 

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -810,7 +810,8 @@ class FeatureOutputSlice(FeatureBase):
 
     @classmethod
     def from_dictionary(cls, arguments, entityset, dependencies, primitives_deserializer):
-        base_feature = arguments['base_feature']
+        base_feature_name = arguments['base_feature']
+        base_feature = dependencies[base_feature_name]
         n = arguments['n']
         name = arguments['name']
         return cls(base_feature=base_feature, n=n, name=name)

--- a/featuretools/feature_base/feature_base.py
+++ b/featuretools/feature_base/feature_base.py
@@ -743,7 +743,7 @@ class Feature(object):
 
     def __new__(self, base, entity=None, groupby=None, parent_entity=None,
                 primitive=None, use_previous=None, where=None):
-        # either direct or indentity
+        # either direct or identity
         if primitive is None and entity is None:
             return IdentityFeature(base)
         elif primitive is None and entity is not None:

--- a/featuretools/tests/primitive_tests/test_feature_base.py
+++ b/featuretools/tests/primitive_tests/test_feature_base.py
@@ -11,6 +11,7 @@ from featuretools.primitives import (
     Diff,
     Last,
     Mode,
+    Negate,
     NMostCommon,
     NumUnique,
     Sum,
@@ -146,14 +147,87 @@ def test_set_data_path(es):
     assert config.get(key) == orig_path
 
 
-def test_to_dictionary(es):
+def test_to_dictionary_direct(es):
     direct_feature = ft.Feature(es["sessions"]["customer_id"], es["log"])
+
     expected = {
         'type': 'DirectFeature',
-        'dependencies': [feat.unique_name() for feat in direct_feature.get_dependencies()],
-        'arguments': direct_feature.get_arguments()
+        'dependencies': ['sessions: customer_id'],
+        'arguments': {'name': None,
+                      'base_feature': 'sessions: customer_id',
+                      'relationship': {'parent_entity_id': 'sessions',
+                                       'child_entity_id': 'log',
+                                       'parent_variable_id': 'id',
+                                       'child_variable_id': 'session_id'}}
     }
+
     assert expected == direct_feature.to_dictionary()
+
+
+def test_to_dictionary_identity(es):
+    identity_feature = ft.Feature(es["sessions"]["customer_id"])
+
+    expected = {
+        'type': 'IdentityFeature',
+        'dependencies': [],
+        'arguments': {'name': None,
+                      'variable_id': 'customer_id',
+                      'entity_id': 'sessions'
+                      }
+    }
+    assert expected == identity_feature.to_dictionary()
+
+
+def test_to_dictionary_agg(es):
+    agg_feature = ft.Feature(es["customers"]["age"],
+                             primitive=Sum, parent_entity=es['cohorts'])
+
+    expected = {
+        'type': 'AggregationFeature',
+        'dependencies': ['customers: age'],
+        'arguments': {'name': None,
+                      'base_features': ['customers: age'],
+                      'relationship_path': [{'parent_entity_id': 'cohorts',
+                                             'child_entity_id': 'customers',
+                                             'parent_variable_id': 'cohort',
+                                             'child_variable_id': 'cohort'}],
+                      'primitive': {'type': 'Sum',
+                                    'module': 'featuretools.primitives.standard.aggregation_primitives',
+                                    'arguments': {}},
+                      'where': None,
+                      'use_previous': None
+                      }
+    }
+    assert expected == agg_feature.to_dictionary()
+
+
+def test_to_dictionary_trans(es):
+    trans_feature = ft.Feature(es["customers"]["age"], primitive=Negate)
+
+    expected = {
+        'type': 'TransformFeature',
+        'dependencies': ['customers: age'],
+        'arguments': {'name': None,
+                      'base_features': ['customers: age'],
+                      'primitive': {'type': 'Negate',
+                                    'module': 'featuretools.primitives.standard.transform_primitive',
+                                    'arguments': {}}
+                      }}
+    assert expected == trans_feature.to_dictionary()
+
+
+def test_to_dictionary_multi_slice(es):
+    slice_feature = ft.Feature(es['log']['product_id'], parent_entity=es['customers'], primitive=NMostCommon(n=2))[0]
+
+    expected = {
+        'type': 'FeatureOutputSlice',
+        'dependencies': ['customers: N_MOST_COMMON(log.product_id, n=2)'],
+        'arguments': {'name': None,
+                      'base_feature': 'customers: N_MOST_COMMON(log.product_id, n=2)',
+                      'n': 0
+                      }}
+
+    assert expected == slice_feature.to_dictionary()
 
 
 def test_multi_output_base_error_agg(es):

--- a/featuretools/tests/primitive_tests/test_feature_base.py
+++ b/featuretools/tests/primitive_tests/test_feature_base.py
@@ -158,7 +158,8 @@ def test_to_dictionary_direct(es):
                       'relationship': {'parent_entity_id': 'sessions',
                                        'child_entity_id': 'log',
                                        'parent_variable_id': 'id',
-                                       'child_variable_id': 'session_id'}}
+                                       'child_variable_id': 'session_id'}
+                      }
     }
 
     assert expected == direct_feature.to_dictionary()
@@ -172,9 +173,9 @@ def test_to_dictionary_identity(es):
         'dependencies': [],
         'arguments': {'name': None,
                       'variable_id': 'customer_id',
-                      'entity_id': 'sessions'
-                      }
+                      'entity_id': 'sessions'}
     }
+
     assert expected == identity_feature.to_dictionary()
 
 
@@ -195,10 +196,33 @@ def test_to_dictionary_agg(es):
                                     'module': 'featuretools.primitives.standard.aggregation_primitives',
                                     'arguments': {}},
                       'where': None,
-                      'use_previous': None
-                      }
+                      'use_previous': None}
     }
+
     assert expected == agg_feature.to_dictionary()
+
+
+def test_to_dictionary_where(es):
+    agg_where = ft.Feature(es['log']['value'], parent_entity=es['sessions'],
+                           where=ft.IdentityFeature(es['log']['value']) == 2, primitive=Sum)
+
+    expected = {
+        'type': 'AggregationFeature',
+        'dependencies': ['log: value', 'log: value = 2'],
+        'arguments': {'name': None,
+                      'base_features': ['log: value'],
+                      'relationship_path': [{'parent_entity_id': 'sessions',
+                                             'child_entity_id': 'log',
+                                             'parent_variable_id': 'id',
+                                             'child_variable_id': 'session_id'}],
+                      'primitive': {'type': 'Sum',
+                                    'module': 'featuretools.primitives.standard.aggregation_primitives',
+                                    'arguments': {}},
+                      'where': 'log: value = 2',
+                      'use_previous': None}
+    }
+
+    assert expected == agg_where.to_dictionary()
 
 
 def test_to_dictionary_trans(es):
@@ -213,7 +237,25 @@ def test_to_dictionary_trans(es):
                                     'module': 'featuretools.primitives.standard.transform_primitive',
                                     'arguments': {}}
                       }}
+
     assert expected == trans_feature.to_dictionary()
+
+
+def test_to_dictionary_grouby_trans(es):
+    groupby_feature = ft.Feature(es['log']['value'], primitive=Negate, groupby=es['log']['product_id'])
+
+    expected = {
+        'type': 'GroupByTransformFeature',
+        'dependencies': ['log: value', 'log: product_id'],
+        'arguments': {'name': None,
+                      'base_features': ['log: value'],
+                      'primitive': {'type': 'Negate',
+                                    'module': 'featuretools.primitives.standard.transform_primitive',
+                                    'arguments': {}},
+                      'groupby': 'log: product_id'}
+    }
+
+    assert expected == groupby_feature.to_dictionary()
 
 
 def test_to_dictionary_multi_slice(es):

--- a/featuretools/tests/primitive_tests/test_feature_serialization.py
+++ b/featuretools/tests/primitive_tests/test_feature_serialization.py
@@ -94,21 +94,6 @@ def test_pickle_features_with_custom_primitive(pd_es, tmpdir):
     pickle_features_test_helper(asizeof(pd_es), features_original, str(tmpdir))
 
 
-def test_pickle_multi_output_features(pd_es, tmpdir):
-    value = ft.IdentityFeature(pd_es['log']['product_id'])
-    threecommon = ft.primitives.NMostCommon()
-    tc = ft.Feature(pd_es['log']['product_id'], parent_entity=pd_es["sessions"], primitive=threecommon)
-
-    features_original = [tc, value]
-    for i in range(3):
-        features_original.append(ft.Feature(tc[i],
-                                            parent_entity=pd_es['customers'],
-                                            primitive=ft.primitives.NumUnique))
-        features_original.append(tc[i])
-
-    pickle_features_test_helper(asizeof(pd_es), features_original, str(tmpdir))
-
-
 def test_serialized_renamed_features(es):
     def serialize_name_unchanged(original):
         new_name = 'MyFeature'

--- a/featuretools/tests/primitive_tests/test_feature_serialization.py
+++ b/featuretools/tests/primitive_tests/test_feature_serialization.py
@@ -94,6 +94,21 @@ def test_pickle_features_with_custom_primitive(pd_es, tmpdir):
     pickle_features_test_helper(asizeof(pd_es), features_original, str(tmpdir))
 
 
+def test_pickle_multi_output_features(pd_es, tmpdir):
+    value = ft.IdentityFeature(pd_es['log']['product_id'])
+    threecommon = ft.primitives.NMostCommon()
+    tc = ft.Feature(pd_es['log']['product_id'], parent_entity=pd_es["sessions"], primitive=threecommon)
+
+    features_original = [tc, value]
+    for i in range(3):
+        features_original.append(ft.Feature(tc[i],
+                                            parent_entity=pd_es['customers'],
+                                            primitive=ft.primitives.NumUnique))
+        features_original.append(tc[i])
+
+    pickle_features_test_helper(asizeof(pd_es), features_original, str(tmpdir))
+
+
 def test_serialized_renamed_features(es):
     def serialize_name_unchanged(original):
         new_name = 'MyFeature'


### PR DESCRIPTION
`FeatureOutputSlice` features were unable to be serialized, so this PR changes their `base_feature` field of the arguments dictionary to be the feature name instead of an actual feature object itself.
