### PR TITLE
Include pyspark and koalas in checkdeps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,5 +30,5 @@ installdeps:
 
 .PHONY: checkdeps
 checkdeps:
-	$(eval allow_list='scipy|numpy|pandas|tqdm|pyyaml|cloudpickle|distributed|dask|psutil|click')
+	$(eval allow_list='scipy|numpy|pandas|tqdm|pyyaml|cloudpickle|distributed|dask|psutil|click|pyspark|koalas')
 	pip freeze | grep -v "FeatureLabs/featuretools.git" | grep -E $(allow_list) > $(OUTPUT_PATH)

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,14 +2,16 @@
 
 Release Notes
 -------------
-.. **Future Release**
+**Future Release**
     * Enhancements
     * Fixes
     * Changes
     * Documentation Changes
     * Testing Changes
+        * Add ``pyspark`` and ``koalas`` to automated dependency checks (:pr:`1191`)
 
-.. Thanks to the following people for contributing to this release:
+Thanks to the following people for contributing to this release:
+:user:`thehomebrewnerd`
 
 **v0.20.0 Sep 30, 2020**
     .. warning::


### PR DESCRIPTION
Update `checkdeps` in Makefile to include pyspark and koalas so that future dependency checks will also track the versions for these.