### PR TITLE
set max koalas version

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -2,14 +2,16 @@
 
 Release Notes
 -------------
-.. **Future Release**
+**Future Release**
     * Enhancements
     * Fixes
     * Changes
     * Documentation Changes
     * Testing Changes
+        * Add ``pyspark`` and ``koalas`` to automated dependency checks (:pr:`1192`)
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`rwedge`
 
 **v0.20.0 Sep 30, 2020**
     .. warning::

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -6,9 +6,9 @@ Release Notes
     * Enhancements
     * Fixes
     * Changes
+        * Restrict koalas version to below 1.3.0 (:pr:`1192`)
     * Documentation Changes
     * Testing Changes
-        * Add ``pyspark`` and ``koalas`` to automated dependency checks (:pr:`1192`)
 
     Thanks to the following people for contributing to this release:
     :user:`rwedge`

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ extras_require = {
     'nlp_primitives': ['nlp-primitives[complete] >= 1.0.0'],
     'autonormalize': ['autonormalize >= 1.0.0'],
     'sklearn_transformer': ['featuretools-sklearn-transformer >= 0.1.1'],
-    'koalas': ['pyspark >= 3.0.0', 'koalas >= 1.1.0']
+    'koalas': ['pyspark >= 3.0.0', 'koalas >= 1.1.0,<1.3.0']
 }
 extras_require['complete'] = sorted(set(sum(extras_require.values(), [])))
 


### PR DESCRIPTION
Some tests failing with koalas 1.3.0, temporarily pinning below 1.3.0 while we investigate
