### PR TITLE
Update last time index code to fix Koalas error

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,9 +5,8 @@ Release Notes
 **Future Release**
     * Enhancements
     * Fixes
-        * Update ``EntitySet.add_last_time_indexes`` to work with Koalas 1.3.0 (:pr:`1202`)
+        * Update ``EntitySet.add_last_time_indexes`` to work with Koalas 1.3.0 (:pr:`1192`, :pr:`1202`)
     * Changes
-        * Restrict koalas version to below 1.3.0 (:pr:`1192`)
         * Keep koalas requirements in separate file (:pr:`1195`)
     * Documentation Changes
         * Added footer to the documentation (:pr:`1189`)

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -5,6 +5,7 @@ Release Notes
 **Future Release**
     * Enhancements
     * Fixes
+        * Update ``EntitySet.add_last_time_indexes`` to work with Koalas 1.3.0 (:pr:`1202`)
     * Changes
         * Restrict koalas version to below 1.3.0 (:pr:`1192`)
         * Keep koalas requirements in separate file (:pr:`1195`)

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -819,7 +819,8 @@ class EntitySet(object):
                         lti.index = entity.df[entity.index].copy()
                         lti = lti.apply(lambda x: None)
                     elif is_instance(entity.df, ks, 'DataFrame'):
-                        lti = ks.Series(index=lti.to_list()).rename(lti.name)
+                        index = lti.to_list()
+                        lti = ks.Series(index=index, data=[None] * len(index), dtype='float64')
                     else:
                         lti[:] = None
                 entity.last_time_index = lti

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -820,7 +820,7 @@ class EntitySet(object):
                         lti = lti.apply(lambda x: None)
                     elif is_instance(entity.df, ks, 'DataFrame'):
                         index = lti.to_list()
-                        lti = ks.Series(index=index, data=[None] * len(index), dtype='float64')
+                        lti = ks.Series(index=index, data=[None] * len(index), dtype='datetime64[ns]')
                     else:
                         lti[:] = None
                 entity.last_time_index = lti

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -819,8 +819,7 @@ class EntitySet(object):
                         lti.index = entity.df[entity.index].copy()
                         lti = lti.apply(lambda x: None)
                     elif is_instance(entity.df, ks, 'DataFrame'):
-                        index = lti.to_list()
-                        lti = ks.Series(index=index, data=[None] * len(index), dtype='datetime64[ns]')
+                        lti = ks.Series(pd.Series(index=lti.to_list()))
                     else:
                         lti[:] = None
                 entity.last_time_index = lti

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -819,7 +819,7 @@ class EntitySet(object):
                         lti.index = entity.df[entity.index].copy()
                         lti = lti.apply(lambda x: None)
                     elif is_instance(entity.df, ks, 'DataFrame'):
-                        lti = ks.Series(pd.Series(index=lti.to_list()))
+                        lti = ks.Series(pd.Series(index=lti.to_list())).rename(lti.name)
                     else:
                         lti[:] = None
                 entity.last_time_index = lti

--- a/featuretools/entityset/entityset.py
+++ b/featuretools/entityset/entityset.py
@@ -819,7 +819,7 @@ class EntitySet(object):
                         lti.index = entity.df[entity.index].copy()
                         lti = lti.apply(lambda x: None)
                     elif is_instance(entity.df, ks, 'DataFrame'):
-                        lti = ks.Series(pd.Series(index=lti.to_list())).rename(lti.name)
+                        lti = ks.Series(pd.Series(index=lti.to_list(), name=lti.name))
                     else:
                         lti[:] = None
                 entity.last_time_index = lti

--- a/koalas-requirements.txt
+++ b/koalas-requirements.txt
@@ -1,2 +1,2 @@
 pyspark >= 3.0.0
-koalas >= 1.1.0,<1.3.0
+koalas >= 1.1.0


### PR DESCRIPTION
### Update add last time index code to fix Koalas error

When Koalas 1.3.0 was released a new error occurred when setting last time indexes as a result. This PR implements changes to fix this error. The updated code was tested with Koalas 1.1.0, 1.2.0 and 1.3.0 and works fine for each. As a result, the upper version restriction on Koalas in `koalas-requirements.txt` was also removed.
