### PR TITLE
Add feature descriptions to feature graphs

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -3,14 +3,16 @@
 Release Notes
 -------------
 
-.. **Future Release**
+**Future Release**
     * Enhancements
+        * Add ability to add feature description captions to feature lineage graphs (:pr:`1212`)
     * Fixes
     * Changes
     * Documentation Changes
     * Testing Changes
 
-.. Thanks to the following people for contributing to this release:
+    Thanks to the following people for contributing to this release:
+    :user:`frances-h`
 
 **v0.21.0 Oct 30, 2020**
     * Enhancements

--- a/featuretools/feature_base/feature_visualizer.py
+++ b/featuretools/feature_base/feature_visualizer.py
@@ -7,6 +7,7 @@ from featuretools.feature_base.feature_base import (
     IdentityFeature,
     TransformFeature
 )
+from featuretools.feature_base.feature_descriptions import describe_feature
 from featuretools.utils.plot_utils import (
     check_graphviz,
     get_graphviz_format,
@@ -27,13 +28,18 @@ TARGET_TEMPLATE = '''
     </TR>'''.format('{}', '{}', target_color=TARGET_COLOR)
 
 
-def graph_feature(feature, to_file=None):
+def graph_feature(feature, to_file=None, description=False, **kwargs):
     '''Generates a feature lineage graph for the given feature
 
     Args:
         feature (FeatureBase) : Feature to generate lineage graph for
         to_file (str, optional) : Path to where the plot should be saved.
             If set to None (as by default), the plot will not be saved.
+        description (bool or str, optional): The feature description to use as a caption
+            for the graph. If False, no description is added. Set to True
+            to use an auto-generated description. Defaults to False.
+        kwargs (keywords): Additional keyword arguments to pass as keyword arguments
+            to the ft.describe_feature function.
 
     Returns:
         graphviz.Digraph : Graph object that can directly be displayed in Jupyter notebooks.
@@ -91,6 +97,11 @@ def graph_feature(feature, to_file=None):
     graph.attr('edge', style='dotted', arrowhead='none', dir='forward')
     for edge in edges[0]:
         graph.edge(*edge)
+
+    if description is True:
+        graph.attr(label=describe_feature(feature, **kwargs))
+    elif description is not False:
+        graph.attr(label=description)
 
     if to_file:
         save_graph(graph, to_file, format_)

--- a/featuretools/tests/primitive_tests/test_feature_visualizer.py
+++ b/featuretools/tests/primitive_tests/test_feature_visualizer.py
@@ -1,4 +1,5 @@
 
+import json
 import os
 import re
 
@@ -20,6 +21,11 @@ from featuretools.primitives import Count, CumMax, Mode, NMostCommon, Year
 @pytest.fixture
 def simple_feat(es):
     return IdentityFeature(es['log']['id'])
+
+
+@pytest.fixture
+def trans_feat(es):
+    return TransformFeature(es['customers']['cancel_date'], Year)
 
 
 def test_returns_digraph_object(simple_feat):
@@ -45,8 +51,8 @@ def test_invalid_format(simple_feat):
         graph_feature(simple_feat, to_file=output_path)
 
 
-def test_transform(es):
-    feat = TransformFeature(es['customers']['cancel_date'], Year)
+def test_transform(es, trans_feat):
+    feat = trans_feat
     graph = graph_feature(feat).source
 
     feat_name = feat.get_name()
@@ -290,8 +296,7 @@ def test_direct(es):
             assert matched
 
 
-def test_stacked(es):
-    trans_feat = TransformFeature(es['customers']['cancel_date'], Year)
+def test_stacked(es, trans_feat):
     stacked = AggregationFeature(trans_feat, es['cohorts'], Mode)
     graph = graph_feature(stacked).source
 
@@ -323,3 +328,40 @@ def test_stacked(es):
     trans_node = re.findall('"{}" \\[label.*'.format(trans_primitive), graph)
     assert len(trans_node) == 1
     assert 'Step 1' in trans_node[0]
+
+
+def test_description_auto_caption(trans_feat):
+    default_graph = graph_feature(trans_feat, description=True).source
+    default_label = 'label="The year of the \\"cancel_date\\"."'
+    assert default_label in default_graph
+
+
+def test_description_auto_caption_metadata(trans_feat, tmpdir):
+    feature_descriptions = {'customers: cancel_date': 'the date the customer cancelled'}
+    primitive_templates = {'year': 'the year that {} occurred'}
+    metadata_graph = graph_feature(trans_feat,
+                                   description=True,
+                                   feature_descriptions=feature_descriptions,
+                                   primitive_templates=primitive_templates).source
+
+    metadata_label = 'label="The year that the date the customer cancelled occurred."'
+    assert metadata_label in metadata_graph
+
+    metadata = {
+        'feature_descriptions': feature_descriptions,
+        'primitive_templates': primitive_templates
+    }
+    metadata_path = os.path.join(tmpdir, 'description_metadata.json')
+    with open(metadata_path, 'w') as f:
+        json.dump(metadata, f)
+    json_metadata_graph = graph_feature(trans_feat,
+                                        description=True,
+                                        metadata_file=metadata_path).source
+    assert metadata_label in json_metadata_graph
+
+
+def test_description_custom_caption(trans_feat):
+    custom_description = 'A custom feature description'
+    custom_description_graph = graph_feature(trans_feat, description=custom_description).source
+    custom_description_label = 'label="A custom feature description"'
+    assert custom_description_label in custom_description_graph


### PR DESCRIPTION
Add ability to add a description of the feature to the feature's graph as a graph caption. A description can either be manually passed in, or `graph_feature` can automatically generate a description with `ft.describe_feature`:

![graph_description](https://user-images.githubusercontent.com/13241412/97900139-4638bf00-1d08-11eb-8d52-d3af50d55391.png)
